### PR TITLE
feat(server): add 3D OSM building tiles

### DIFF
--- a/server/pkg/builtin/manifest.yml
+++ b/server/pkg/builtin/manifest.yml
@@ -1290,7 +1290,7 @@ extensions:
             - id: sourceType
               type: string
               title: Source type
-              description: choose the tiles source type between 3D tileset or OSM building.
+              description: Choose between an external 3D tileset or the OSM building 3d tileset.
               defaultValue: url
               choices:
                 - key: url

--- a/server/pkg/builtin/manifest.yml
+++ b/server/pkg/builtin/manifest.yml
@@ -1314,10 +1314,6 @@ extensions:
               title: Shadows
               description: Enables shadows. Also shadows in the scene should be enabled. Rendering may become overloaded.
               defaultValue: disabled
-              availableIf:
-                field: sourceType
-                type: string
-                value: url
               choices:
                 - key: disabled
                   label: Disabled

--- a/server/pkg/builtin/manifest.yml
+++ b/server/pkg/builtin/manifest.yml
@@ -1295,7 +1295,7 @@ extensions:
               choices:
                 - key: url
                   label: URL
-                - key: OSM
+                - key: osm
                   label: OSM Buildings
             - id: tileset
               type: url

--- a/server/pkg/builtin/manifest.yml
+++ b/server/pkg/builtin/manifest.yml
@@ -1287,10 +1287,24 @@ extensions:
         - id: default
           title: Model
           fields:
+            - id: sourceType
+              type: string
+              title: Source type
+              description: choose the tiles source type between 3D tileset or OSM building.
+              defaultValue: url
+              choices:
+                - key: url
+                  label: URL
+                - key: OSM
+                  label: OSM Buildings
             - id: tileset
               type: url
               title: Tileset URL
               description: A path to tileset.json in 3D tiles
+              availableIf:
+                field: sourceType
+                type: string
+                value: url
             - id: styleUrl
               type: url
               title: Styling URL
@@ -1300,6 +1314,10 @@ extensions:
               title: Shadows
               description: Enables shadows. Also shadows in the scene should be enabled. Rendering may become overloaded.
               defaultValue: disabled
+              availableIf:
+                field: sourceType
+                type: string
+                value: url
               choices:
                 - key: disabled
                   label: Disabled

--- a/server/pkg/builtin/manifest_ja.yml
+++ b/server/pkg/builtin/manifest_ja.yml
@@ -570,14 +570,14 @@ extensions:
         title: 3Dタイル
         fields:
           sourceType:
-            title: Source type
-            description: choose the tiles source type between 3D tileset or OSM building.
+            title: 種類
+            description: 3Dタイルの種類を選択します。
             choices:
               url: URL
-              OSM: OSM Buildings
+              osm: OSM Buildings
           tileset:
-            title: Tileset URL
-            description: A path to tileset.json in 3D tiles
+            title: タイルセットURL
+            description: 3Dタイルデータ内の tileset.json のURL
           styleUrl:
             title: スタイルURL
             description: 3D Tiles styles が記述されたJSONのURL。スタイルを適用することができます。設定は任意です。

--- a/server/pkg/builtin/manifest_ja.yml
+++ b/server/pkg/builtin/manifest_ja.yml
@@ -569,9 +569,15 @@ extensions:
       default:
         title: 3Dタイル
         fields:
+          sourceType:
+            title: Source type
+            description: choose the tiles source type between 3D tileset or OSM building.
+            choices:
+              url: URL
+              OSM: OSM Buildings
           tileset:
-            title: タイルセットURL
-            description: 3Dタイルデータ内の tileset.json のURL
+            title: Tileset URL
+            description: A path to tileset.json in 3D tiles
           styleUrl:
             title: スタイルURL
             description: 3D Tiles styles が記述されたJSONのURL。スタイルを適用することができます。設定は任意です。


### PR DESCRIPTION
# Overview
 OSM Buildings is a 3D buildings layer covering the entire world. It's available as a 3D Tileset on Cesium.
we modified reearth back end in  way that allows the user to add OSM building 3d Tileset as a layer in his project by providing him with an interface to chose which tiles to show on the map.

## What I've done
- modify manifes.yml and add the new attributes related to 3D OSM building tiles.
- add the Japanese translation to manifest.ja.yml 

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo

## Design

https://www.figma.com/file/bdnfDaGXGoNfUws4y7JItl/Re%3AEarth-UI-Gamma?node-id=11576%3A179143
