### PR TITLE
fix(server): prefer dataset values when merging properties

### DIFF
--- a/server/pkg/property/sealed_test.go
+++ b/server/pkg/property/sealed_test.go
@@ -447,13 +447,13 @@ func TestSealed_Interface(t *testing.T) {
 				"x": []map[string]interface{}{
 					{
 						"a":  "a",
-						"b":  "bbb",
+						"b":  "b",
 						"id": i5id.String(),
 					},
 				},
 				"y": map[string]interface{}{
 					"a": "aaa",
-					"b": "bbb",
+					"b": "aaa",
 				},
 			},
 		},

--- a/server/pkg/property/value_dataset.go
+++ b/server/pkg/property/value_dataset.go
@@ -56,7 +56,7 @@ func (v *ValueAndDatasetValue) Value() *Value {
 	if v == nil || v.t == ValueTypeUnknown {
 		return nil
 	}
-	if v.d != nil {
+	if v.d != nil && v.p == nil {
 		return valueFromDataset(v.d)
 	}
 	return v.p

--- a/server/pkg/property/value_dataset_test.go
+++ b/server/pkg/property/value_dataset_test.go
@@ -295,7 +295,7 @@ func TestValueAndDatasetValue_Value(t *testing.T) {
 				d: dataset.ValueTypeString.MustBeValue("foo"),
 				p: ValueTypeString.MustBeValue("bar"),
 			},
-			want: ValueTypeString.MustBeValue("foo"),
+			want: ValueTypeString.MustBeValue("bar"),
 		},
 		{
 			name:   "empty",


### PR DESCRIPTION
# Overview
the new condition:
- if datast value is not nil and the property value is nil -> fetch the dataset value
- otherwise fetch property value