### PR TITLE
chore(ci): add conditional in ci-web and ci-server for renovate commits

### DIFF
--- a/.github/workflows/ci_collect_info.yml
+++ b/.github/workflows/ci_collect_info.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
     info:
-        name: Collect information(server build)
+        name: Collect information
         runs-on: ubuntu-latest
         if: ${{ github.event.workflow_run.conclusion != 'failure' && github.event.repository.full_name == 'reearth/reearth' && (startsWith(github.event.workflow_run.head_branch, 'release/') || github.event.workflow_run.head_branch == 'main' || !startsWith(github.event.head_commit.message, 'v')) }}
         outputs:

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ci:
-    name: Check server change
+    name: ci
     runs-on: ubuntu-latest
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'v')
     defaults:

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -12,6 +12,7 @@ jobs:
   ci:
     name: Check server change
     runs-on: ubuntu-latest
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'v')
     defaults:
       run:
         working-directory: server

--- a/.github/workflows/ci_web.yml
+++ b/.github/workflows/ci_web.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ci:
-    name: Check and build web change
+    name: ci
     runs-on: ubuntu-latest
     if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'v')
     defaults:

--- a/.github/workflows/ci_web.yml
+++ b/.github/workflows/ci_web.yml
@@ -12,6 +12,7 @@ jobs:
   ci:
     name: Check and build web change
     runs-on: ubuntu-latest
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'v')
     defaults:
       run:
         working-directory: web


### PR DESCRIPTION
# Overview
This PR add conditional check on `ci-web` and `ci-server` to avoid triggering their workflow's job if the commit is created by renovate.