### PR TITLE
fix(web): feature containing layer show hide not working

### DIFF
--- a/web/src/core/engines/Cesium/Feature/index.tsx
+++ b/web/src/core/engines/Cesium/Feature/index.tsx
@@ -95,7 +95,9 @@ export default function Feature({
     k: keyof AppearanceTypes,
     f?: ComputedFeature,
   ): JSX.Element | null => {
-    const componentId = `${layer.id}_${f?.id ?? ""}_${k}_${JSON.stringify(f?.[k]) ?? ""}`;
+    const componentId = `${layer.id}_${f?.id ?? ""}_${k}_${isHidden}_${
+      JSON.stringify(f?.[k]) ?? ""
+    }`;
 
     // Check if the component output is already cached
     const cachedComponent = CACHED_COMPONENTS.get(componentId);


### PR DESCRIPTION
# Overview
This PR fixes an issue observed with layers with features in them like e.g geojson where the show/hide feature wasn't functional.