### PR TITLE
ci: add release in the ci release flow

### DIFF
--- a/.github/workflows/ci_collect_info.yml
+++ b/.github/workflows/ci_collect_info.yml
@@ -1,7 +1,7 @@
 name: collect-info
 on:
   push:
-    branches: [main, release/*]
+    branches: [main, release/*, release]
 
   workflow_call:
     # Map the workflow outputs to job outputs
@@ -19,7 +19,7 @@ jobs:
     info:
         name: Collect information
         runs-on: ubuntu-latest
-        if: ${{ github.event.workflow_run.conclusion != 'failure' && github.event.repository.full_name == 'reearth/reearth' && (startsWith(github.event.workflow_run.head_branch, 'release/') || github.event.workflow_run.head_branch == 'main' || !startsWith(github.event.head_commit.message, 'v')) }}
+        if: ${{ github.event.workflow_run.conclusion != 'failure' && github.event.repository.full_name == 'reearth/reearth' && (startsWith(github.event.workflow_run.head_branch, 'release') || github.event.workflow_run.head_branch == 'main' || !startsWith(github.event.head_commit.message, 'v')) }}
         outputs:
           sha_short: ${{ steps.info.outputs.sha_short }}
           new_tag: ${{ steps.info.outputs.new_tag }}

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -1,7 +1,7 @@
 name: ci-server
 on:
   push:
-    branches: [main, release/*]
+    branches: [main, release/*, release]
     paths:
       - server/**
   pull_request:

--- a/.github/workflows/ci_server_build.yml
+++ b/.github/workflows/ci_server_build.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: [ci-server]
     types: [completed]
-    branches: [main, release/*]
+    branches: [main, release/*, release]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true

--- a/.github/workflows/ci_web.yml
+++ b/.github/workflows/ci_web.yml
@@ -1,7 +1,7 @@
 name: ci-web
 on:
   push:
-    branches: [main, release/*]
+    branches: [main, release/*, release]
     paths:
       - web/**
   pull_request:

--- a/.github/workflows/ci_web_build.yml
+++ b/.github/workflows/ci_web_build.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: [ci-web]
     types: [completed]
-    branches: [main, release/*]
+    branches: [main, release/*, release]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true


### PR DESCRIPTION
# Overview
This PR adds `release` as one of the possible branches in `ci` workflows.