### PR TITLE
fix(web): classic infobox always shown for 3d tiles

### DIFF
--- a/web/src/components/molecules/Visualizer/hooks.ts
+++ b/web/src/components/molecules/Visualizer/hooks.ts
@@ -371,7 +371,7 @@ function useLayers({
             infoboxKey: selectedLayer?.id,
             title: layerOverridenInfobox?.title || selectedLayer?.title,
             isEditable: !layerOverridenInfobox && !!selectedLayer?.infobox,
-            visible: !!selectedLayer?.infobox || !!layerOverridenInfobox,
+            visible: !!selectedLayer?.infobox,
             layer: selectedLayer,
             blocks,
           }


### PR DESCRIPTION
# Overview

For classic layer system, infobox should only shown when user added an infobox to the layer.
Currently when select a 3d tiles the overriden infobox will show up, which is not the expected behavior.

## What I've done

Show classic infobox only when selected layer has infobox.

## What I haven't done

## How I tested

- Test in local.
- Test in plugin editor with:
```js
reearth.layers.add({
  extensionId: "tileset",
  isVisible: true,
  title: `3D Tiles`,
  property: {
    default: {
      tileset: 'https://assets.cms.plateau.reearth.io/assets/11/6d05db-ed47-4f88-b565-9eb385b1ebb0/13100_tokyo23-ku_2022_3dtiles%20_1_1_op_bldg_13101_chiyoda-ku_lod1/tileset.json'
    },
  },
  // infobox: {
  //   blocks:[],
  //   property:{
  //     default:{
  //       title: '3D Tiles Infobox'
  //     }
  //   }
  // },
});
```

## Which point I want you to review particularly

## Memo
