### PR TITLE
fix(web): create new workspace doesn't save session

### DIFF
--- a/web/src/components/organisms/Dashboard/hooks.ts
+++ b/web/src/components/organisms/Dashboard/hooks.ts
@@ -97,7 +97,7 @@ export default (workspaceId?: string) => {
           text: t("Successfully created workspace!"),
         });
         setCurrentWorkspace(results.data.createTeam.team);
-        setLastWorkspace(currentWorkspace);
+        setLastWorkspace(results.data.createTeam.team);
         navigate(`/dashboard/${results.data.createTeam.team.id}`);
       }
       refetch();
@@ -109,7 +109,6 @@ export default (workspaceId?: string) => {
       t,
       setCurrentWorkspace,
       setLastWorkspace,
-      currentWorkspace,
       navigate,
     ],
   );

--- a/web/src/components/organisms/EarthEditor/Header/hooks.ts
+++ b/web/src/components/organisms/EarthEditor/Header/hooks.ts
@@ -192,12 +192,12 @@ export default () => {
       });
       if (results.data?.createTeam) {
         setWorkspace(results.data.createTeam.team);
-        setLastWorkspace(currentWorkspace);
+        setLastWorkspace(results.data.createTeam.team);
 
         navigate(`/dashboard/${results.data.createTeam.team.id}`);
       }
     },
-    [createTeamMutation, setWorkspace, setLastWorkspace, currentWorkspace, navigate],
+    [createTeamMutation, setWorkspace, setLastWorkspace, navigate],
   );
 
   useEffect(() => {

--- a/web/src/components/organisms/Settings/SettingPage/hooks.ts
+++ b/web/src/components/organisms/Settings/SettingPage/hooks.ts
@@ -115,10 +115,10 @@ export default (params: Params) => {
       const workspace = results.data?.createTeam?.team;
       if (results) {
         setWorkspace(workspace);
-        setLastWorkspace(currentWorkspace);
+        setLastWorkspace(workspace);
       }
     },
-    [createTeamMutation, currentWorkspace, setLastWorkspace, setWorkspace],
+    [createTeamMutation, setLastWorkspace, setWorkspace],
   );
 
   return {

--- a/web/src/components/organisms/Settings/Workspace/hooks.ts
+++ b/web/src/components/organisms/Settings/Workspace/hooks.ts
@@ -90,7 +90,7 @@ export default (params: Params) => {
         });
       } else {
         setWorkspace(workspace);
-        setLastWorkspace(currentWorkspace);
+        setLastWorkspace(workspace);
 
         setNotification({
           type: "success",
@@ -99,7 +99,7 @@ export default (params: Params) => {
       }
       setModalShown(false);
     },
-    [createTeamMutation, setNotification, t, setWorkspace, setLastWorkspace, currentWorkspace],
+    [createTeamMutation, setNotification, t, setWorkspace, setLastWorkspace],
   );
 
   const [updateTeamMutation] = useUpdateTeamMutation();


### PR DESCRIPTION
# Overview
When user create a new workspace it doesn't save in session , so when he opens a new tabs the last workspace is returned wrongly
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
