### PR TITLE
chore(server): Add REEARTH_ASSETBASEURL to /server/.env.example

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -3,7 +3,7 @@ PORT=8080
 REEARTH_DB=mongodb://localhost
 REEARTH_HOST=https://localhost:8080
 REEARTH_HOST_WEB=https://localhost:3000
-REEARTH_ASSETBASEURL=https://localhost:3000/assets
+REEARTH_ASSETBASEURL=https://localhost:8080/assets
 REEARTH_DEV=false
 
 # GCP

--- a/server/.env.example
+++ b/server/.env.example
@@ -3,6 +3,7 @@ PORT=8080
 REEARTH_DB=mongodb://localhost
 REEARTH_HOST=https://localhost:8080
 REEARTH_HOST_WEB=https://localhost:3000
+REEARTH_ASSETBASEURL=https://localhost:3000/assets
 REEARTH_DEV=false
 
 # GCP


### PR DESCRIPTION
Setting AssetBaseURL config value is necessary in order to run a custom domain server.
I added the corresponding REEARTH_ASSETBASEURL environment variable to `/server/.env.example`, to avoid future confusion.