### PR TITLE
chore: remove netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,0 @@
-[build]
-  base = "web/"
-  publish = "web/dist"
-  command = "yarn build:preview && (cd dist && curl -O https://test.reearth.dev/reearth_config.json)"
-
-[[redirects]]
-  from = "/web/*"
-  to = "/web/index.html"
-  status = 200


### PR DESCRIPTION
# Overview
This PR temporarily removes `netlify.toml` file temporarily from the root.
