### PR TITLE
fix(web): auth0 error when refresh token

### DIFF
--- a/web/src/auth/provider.tsx
+++ b/web/src/auth/provider.tsx
@@ -13,9 +13,10 @@ const Provider: React.FC<{ children?: ReactNode }> = ({ children }) => {
       authorizationParams={{
         audience: audience,
         scope: "openid profile email offline_access",
-        redirectUri: window.location.origin,
+        redirect_uri: window.location.origin,
       }}
       useRefreshTokens
+      useRefreshTokensFallback
       cacheLocation="localstorage">
       {children}
     </Auth0Provider>


### PR DESCRIPTION
# Overview

Reference [here](https://community.auth0.com/t/auth0-spa-2-x-returning-missing-refresh-token/98999/15).

## What I've done

- Fix: add `useRefreshTokensFallback` to `Auth0Provider` authorizationParams.
- Rename `redirectUri` to `redirect_uri`: the old naming is going to be removed in the future base on auth0 doc.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
