### PR TITLE
ci: fix git hook, ESLint and CI setting to work properly

### DIFF
--- a/.github/workflows/ci_web.yml
+++ b/.github/workflows/ci_web.yml
@@ -36,7 +36,7 @@ jobs:
         - name: type
           run: yarn run type
         - name: eslint
-          run: yarn run eslint
+          run: yarn run lint
         - name: Check
           run: yarn run coverage
         - name: Send coverage report

--- a/.github/workflows/ci_web.yml
+++ b/.github/workflows/ci_web.yml
@@ -35,6 +35,8 @@ jobs:
           run: yarn install
         - name: type
           run: yarn run type
+        - name: eslint
+          run: yarn run eslint
         - name: Check
           run: yarn run coverage
         - name: Send coverage report

--- a/web/.eslintignore
+++ b/web/.eslintignore
@@ -1,0 +1,7 @@
+/build
+/dist
+/coverage
+/storybook-static
+!/.storybook
+/.storybook/public
+/src/services/gql/graphql-client-api.tsx

--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -5,11 +5,11 @@ import {
   ApolloLink,
   Observable,
 } from "@apollo/client";
-import React, { ReactElement } from "react";
+import { ReactElement } from "react";
 
+import { Provider as DndProvider } from "../src/classic/util/use-dnd";
 import { Provider as I18nProvider } from "../src/services/i18n";
 import { Provider as ThemeProvider } from "../src/services/theme";
-import { Provider as DndProvider } from "../src/classic/util/use-dnd";
 
 // apollo client that does nothing
 const mockClient = new ApolloClient({

--- a/web/package.json
+++ b/web/package.json
@@ -28,7 +28,7 @@
         "node": ">=16"
     },
     "lint-staged": {
-        "web/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}": "eslint --fix"
+        "**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}": "eslint --fix"
     },
     "devDependencies": {
         "@emotion/jest": "11.11.0",


### PR DESCRIPTION
# Overview

This PR solves these problems.
- `yarn eslint` will freeze while it's running.
- Compared to old repository, there are some missing file
- `lint-staged` does not catch any staged files when running git-hook

## What I've done

- Add eslintignore
  - Old repository had ignored `graphql-client-api.tsx` which is the cause of the freezing problem
  - https://github.com/reearth/reearth-web/blob/main/.eslintignore#L8
- Add CI task
  - Old repository had the task in CI
  - https://github.com/reearth/reearth-web/blob/main/package.json#L18
  - https://github.com/reearth/reearth-web/blob/main/.github/workflows/ci.yml#L32
- Fix `lint-staged` setting

## What I haven't done

## How I tested

Manually run `yarn lint` and `yarn lint-staged` in my local.
CI will be displayed in this PR.

## Which point I want you to review particularly

## Memo
