### PR TITLE
chore(web): improve storybook preview setting

### DIFF
--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -5,6 +5,7 @@ import {
   ApolloLink,
   Observable,
 } from "@apollo/client";
+import type { Preview } from "@storybook/react";
 import { ReactElement } from "react";
 
 import { Provider as DndProvider } from "../src/classic/util/use-dnd";
@@ -22,19 +23,23 @@ const mockClient = new ApolloClient({
   cache: new InMemoryCache(),
 });
 
-export const parameters = {
-  layout: "fullscreen",
-  controls: { expanded: true },
+const preview: Preview = {
+  parameters: {
+    layout: "fullscreen",
+    controls: { expanded: true },
+    actions: { argTypesRegex: "^on.*" },
+  },
+  decorators: [
+    (storyFn: () => ReactElement) => (
+      <ApolloProvider client={mockClient}>
+        <ThemeProvider>
+          <I18nProvider>
+            <DndProvider>{storyFn()}</DndProvider>
+          </I18nProvider>
+        </ThemeProvider>
+      </ApolloProvider>
+    ),
+  ],
 };
 
-export const decorators = [
-  (storyFn: () => ReactElement) => (
-    <ApolloProvider client={mockClient}>
-      <ThemeProvider>
-        <I18nProvider>
-          <DndProvider>{storyFn()}</DndProvider>
-        </I18nProvider>
-      </ThemeProvider>
-    </ApolloProvider>
-  ),
-];
+export default preview;


### PR DESCRIPTION
# Overview

I've done the following improvement for Storybook preview setting.

- Use explicit typing
- Use `argTypesRegex` in default. We don't need to set it in every Storybook definition.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
