### PR TITLE
fix(web): updateClockLoad deafault true in beta-core

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/Feature/Resource/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Resource/index.tsx
@@ -61,7 +61,7 @@ export default function Resource({
     return [
       type ?? (data?.type as ResourceAppearance["type"]),
       url ?? data?.url,
-      !!data?.time?.updateClockOnLoad,
+      data?.time?.updateClockOnLoad ?? true,
     ];
   }, [property, layer]);
   const { viewer } = useCesium();


### PR DESCRIPTION
# Overview
This PR applies the same changes as the https://github.com/reearth/reearth/pull/470 which I forgot reflect on the beta side of the core lib.
