### PR TITLE
ci: fix build deadlock after ci finishes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - ci
       - ci-web
     runs-on: ubuntu-latest
-    if: !failure() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))
+    if: $${{!failure() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))}}
     steps:
       - name: Dispatch Web Build
         uses: peter-evans/repository-dispatch@v2
@@ -66,7 +66,7 @@ jobs:
       - ci
       - ci-server
     runs-on: ubuntu-latest
-    if: !failure() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))
+    if: ${{!failure() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))}}
     steps:
       - name: Dispatch Web Build
         uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,18 +51,22 @@ jobs:
     steps:
       - run: echo OK
   build-web:
-    needs: ci
+    needs: 
+      - ci
+      - ci-web
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))
+    if: !failure() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))
     steps:
       - name: Dispatch Web Build
         uses: peter-evans/repository-dispatch@v2
         with:
           event-type: build-web
   build-server:
-    needs: ci
+    needs: 
+      - ci
+      - ci-server
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))
+    if: !failure() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))
     steps:
       - name: Dispatch Web Build
         uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - ci
       - ci-web
     runs-on: ubuntu-latest
-    if: $${{!failure() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))}}
+    if: ${{!failure() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))}}
     steps:
       - name: Dispatch Web Build
         uses: peter-evans/repository-dispatch@v2


### PR DESCRIPTION
# Overview
This PR fixes skipped workflow issue faced in https://github.com/reearth/reearth/actions/runs/5200171904