### PR TITLE
ci(web): use workflow-dispatch action to trigger next branch workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,9 @@ jobs:
     if: ${{!failure() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))}}
     steps:
       - name: Dispatch Web Build
-        uses: peter-evans/repository-dispatch@v2
+        uses: benc-uk/workflow-dispatch@v1
         with:
-          event-type: build-web
+          workflow: build_web.yml
   build-server:
     needs: 
       - ci
@@ -69,6 +69,6 @@ jobs:
     if: ${{!failure() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))}}
     steps:
       - name: Dispatch Web Build
-        uses: peter-evans/repository-dispatch@v2
+        uses: benc-uk/workflow-dispatch@v1
         with:
-          event-type: build-server
+          workflow: build_server.yml


### PR DESCRIPTION
# Overview
The repository_dispatch action does not support triggering workflow on a custom branch, see https://github.com/peter-evans/repository-dispatch/issues/39#issuecomment-671657524. We can't test this before the release but it should work. We need to trigger the workflow from the next branch since it differs from the main one. Another approach would be merging the next workflow to main, but that is confusing and harder to maintain.