### PR TITLE
ci(server, web): fix workflow dispatch input for correct ref head_branch

### DIFF
--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -1,6 +1,13 @@
 name: build-server
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Target branch'
+        required: true
+      ref:
+        description: 'Ref'
+        required: false
   repository_dispatch:
     types: [build-server]
 jobs:
@@ -16,14 +23,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.ref.head_sha }}
       - name: Fetch tags
         run: git fetch --prune --unshallow --tags
       - name: Get info
         id: info
         # The tag name should be retrieved lazily, as tagging may be delayed.
         env:
-          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          BRANCH: ${{ github.event.inputs.branch }}
         run: |
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
           echo "BRANCH=$BRANCH"

--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -1,6 +1,13 @@
 name: build-web
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Target branch'
+        required: true
+      ref:
+        description: 'Ref'
+        required: false
   repository_dispatch:
       types: [build-web]
 jobs:
@@ -16,14 +23,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.ref.head_sha }}
       - name: Fetch tags
         run: git fetch --prune --unshallow --tags
       - name: Get info
         id: info
         # The tag name should be retrieved lazily, as tagging may be delayed.
         env:
-          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          BRANCH: ${{ github.event.inputs.branch }}
         run: |
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
           echo "BRANCH=$BRANCH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: build_web.yml
+          inputs: '{ "branch": "${{ github.ref_name}}", "ref": "${{ github.ref }}"}'
   build-server:
     needs: 
       - ci
@@ -72,3 +73,4 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: build_server.yml
+          inputs: '{ "branch": "${{ github.ref_name}}", "ref": "${{ github.ref }}"}'

--- a/.github/workflows/ci_collect_info.yml
+++ b/.github/workflows/ci_collect_info.yml
@@ -33,7 +33,7 @@ jobs:
             id: info
             # The tag name should be retrieved lazily, as tagging may be delayed.
             env:
-              BRANCH: ${{ github.event.workflow_run.head_branch }}
+              BRANCH: ${{ github.event.inputs}}
             run: |
               echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
               if [[ "$BRANCH" = "release" || "$BRANCH" = "release/"* ]]; then


### PR DESCRIPTION
# Overview
This PR attempts to fix an issue raised by using workflow_dispatch which requires inputs to get the correct brach name and the rest of ref info.
