### PR TITLE
feat(web): add an option to disable default PBR to 3dtiles and model features in NLS

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/CustomShaders/NonPBRLightingShader.ts
+++ b/web/src/beta/lib/core/engines/Cesium/CustomShaders/NonPBRLightingShader.ts
@@ -1,0 +1,20 @@
+import {
+  CustomShader,
+  CustomShaderMode,
+  CustomShaderTranslucencyMode,
+  LightingModel,
+} from "cesium";
+
+export const NonPBRLightingShader = new CustomShader({
+  mode: CustomShaderMode.MODIFY_MATERIAL, // Need lighting
+  lightingModel: LightingModel.PBR,
+  translucencyMode: CustomShaderTranslucencyMode.OPAQUE,
+  fragmentShaderText: /* glsl */ `
+    void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {
+      material.diffuse = vec3(1.0);
+      material.specular = vec3(0.0);
+      material.emissive = vec3(0.0);
+      material.alpha = 1.0;
+    }
+  `,
+});

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Model/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Model/index.tsx
@@ -6,6 +6,7 @@ import { toColor } from "@reearth/beta/utils/value";
 
 import type { ModelAppearance } from "../../..";
 import { colorBlendMode, heightReference, shadowMode } from "../../common";
+import { NonPBRLightingShader } from "../../CustomShaders/NonPBRLightingShader";
 import {
   EntityExt,
   extractSimpleLayerData,
@@ -62,6 +63,7 @@ export default function Model({ id, isVisible, property, geometry, layer, featur
     silhouetteColor,
     bearing,
     silhouetteSize = 1,
+    pbr,
   } = property ?? {};
 
   const actualUrl = useMemo(() => model || url || data?.url, [model, url, data?.url]);
@@ -107,6 +109,7 @@ export default function Model({ id, isVisible, property, geometry, layer, featur
         uri={actualUrl}
         scale={scale}
         shadows={shadowMode(shadows)}
+        customShader={!pbr ? NonPBRLightingShader : undefined}
         colorBlendMode={colorBlendMode(colorBlend)}
         colorBlendAmount={colorBlendAmount}
         color={modelColor}

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Model/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Model/index.tsx
@@ -109,7 +109,7 @@ export default function Model({ id, isVisible, property, geometry, layer, featur
         uri={actualUrl}
         scale={scale}
         shadows={shadowMode(shadows)}
-        customShader={!pbr ? NonPBRLightingShader : undefined}
+        customShader={pbr === false ? NonPBRLightingShader : undefined}
         colorBlendMode={colorBlendMode(colorBlend)}
         colorBlendAmount={colorBlendAmount}
         color={modelColor}

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Tileset/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Tileset/index.tsx
@@ -3,6 +3,7 @@ import { Cesium3DTileset } from "resium";
 
 import type { Cesium3DTilesAppearance, ComputedLayer } from "../../..";
 import { colorBlendModeFor3DTile, shadowMode } from "../../common";
+import { NonPBRLightingShader } from "../../CustomShaders/NonPBRLightingShader";
 import Box from "../Box";
 import { type FeatureComponentConfig, type FeatureProps } from "../utils";
 
@@ -23,7 +24,7 @@ function Tileset({
   evalFeature,
   ...props
 }: Props): JSX.Element | null {
-  const { shadows, colorBlendMode } = property ?? {};
+  const { shadows, colorBlendMode, pbr } = property ?? {};
   const boxId = `${layer?.id}_box`;
   const { tilesetUrl, ref, style, clippingPlanes, builtinBoxProps } = useHooks({
     id,
@@ -49,6 +50,7 @@ function Tileset({
       <Cesium3DTileset
         ref={ref}
         url={tilesetUrl}
+        customShader={pbr === false ? NonPBRLightingShader : undefined}
         style={style}
         shadows={shadowMode(shadows)}
         clippingPlanes={clippingPlanes}

--- a/web/src/beta/lib/core/mantle/types/appearance.ts
+++ b/web/src/beta/lib/core/mantle/types/appearance.ts
@@ -131,6 +131,7 @@ export type ModelAppearance = {
   silhouetteSize?: number; // default: 1
   near?: number;
   far?: number;
+  pbr?: boolean;
 };
 
 export type Cesium3DTilesAppearance = {
@@ -145,6 +146,7 @@ export type Cesium3DTilesAppearance = {
   experimental_clipping?: EXPERIMENTAL_clipping;
   pointSize?: number;
   meta?: unknown;
+  pbr?: boolean;
 };
 
 export type LegacyPhotooverlayAppearance = {


### PR DESCRIPTION
# Overview

CustomShader: https://cesium.com/learn/cesiumjs/ref-doc/CustomShader.html
The original implementation: https://github.com/takram-design-engineering/plateau-view/blob/00fc34eda3d0b22eb7a115a948a6901f0926f860/libs/datasets/src/LambertDiffuseShader.ts#L8

|PBR|Non PBR|
|:--:|:--:|
|![Screenshot 2023-06-23 at 16 39 01](https://github.com/reearth/reearth/assets/34934510/716d3b0e-a621-4fe8-b95a-973d10448054)|![Screenshot 2023-06-23 at 16 46 56](https://github.com/reearth/reearth/assets/34934510/67cc3f43-c0ea-4861-b5b1-ad904bbf0770)|

## What I've done

- Added `pbr` property to `3dtiles` and `model` appearance.

## What I haven't done

## How I tested

1. Add 3dtiles as follow
```
reearth.layers.add({
  type: "simple",
  data: {
    type: "3dtiles",
    url: "https://assets.cms.plateau.reearth.io/assets/4f/702958-5009-4d6b-a2e0-157c7e573eb2/13100_tokyo23-ku_2022_3dtiles%20_1_1_op_bldg_13101_chiyoda-ku_lod2_no_texture/tileset.json",
  },
  "3dtiles": {
      pbr: false
  }
});
```
2. PBR should be used in default.

## Which point I want you to review particularly

## Memo
