### PR TITLE
fix(web): revert functionality to remember last workspace opened

### DIFF
--- a/web/src/beta/features/Navbar/hooks.ts
+++ b/web/src/beta/features/Navbar/hooks.ts
@@ -7,7 +7,7 @@ import {
   useGetProjectBySceneQuery,
   useGetTeamsQuery,
 } from "@reearth/services/gql";
-import { useProject, useSessionWorkspace, useWorkspace } from "@reearth/services/state";
+import { useProject, useWorkspace } from "@reearth/services/state";
 
 type User = {
   name: string;
@@ -16,9 +16,8 @@ type User = {
 export default (sceneId: string) => {
   const { logout: handleLogout } = useAuth();
 
-  const [currentWorkspace, setWorkspace] = useSessionWorkspace();
+  const [currentWorkspace, setCurrentWorkspace] = useWorkspace();
   const [currentProject, setProject] = useProject();
-  const [lastWorkspace, setLastWorkspace] = useWorkspace();
 
   const [workspaceModalVisible, setWorkspaceModalVisible] = useState(false);
 
@@ -59,16 +58,6 @@ export default (sceneId: string) => {
   const handleWorkspaceModalClose = useCallback(() => setWorkspaceModalVisible(false), []);
 
   useEffect(() => {
-    if (!currentWorkspace && lastWorkspace && workspaceId == lastWorkspace.id)
-      setWorkspace(lastWorkspace);
-    else {
-      const workspace = workspaces?.find(workspace => workspace.id === workspaceId);
-      setWorkspace(workspace);
-      setLastWorkspace(workspace);
-    }
-  }, [currentWorkspace, lastWorkspace, setLastWorkspace, setWorkspace, workspaceId, workspaces]);
-
-  useEffect(() => {
     setProject(p =>
       p?.id !== project?.id
         ? project
@@ -87,13 +76,12 @@ export default (sceneId: string) => {
     (workspaceId: string) => {
       const workspace = workspaces?.find(team => team.id === workspaceId);
       if (workspace && workspaceId !== currentWorkspace?.id) {
-        setWorkspace(workspace);
-        setLastWorkspace(currentWorkspace);
+        setCurrentWorkspace(workspace);
 
         navigate(`/dashboard/${workspaceId}`);
       }
     },
-    [workspaces, currentWorkspace, setWorkspace, setLastWorkspace, navigate],
+    [workspaces, currentWorkspace, setCurrentWorkspace, navigate],
   );
 
   const [createTeamMutation] = useCreateTeamMutation();
@@ -105,13 +93,12 @@ export default (sceneId: string) => {
         refetchQueries: ["GetTeams"],
       });
       if (results.data?.createTeam) {
-        setWorkspace(results.data.createTeam.team);
-        setLastWorkspace(results.data.createTeam.team);
+        setCurrentWorkspace(results.data.createTeam.team);
 
         navigate(`/dashboard/${results.data.createTeam.team.id}`);
       }
     },
-    [createTeamMutation, setWorkspace, setLastWorkspace, navigate],
+    [createTeamMutation, setCurrentWorkspace, navigate],
   );
 
   return {

--- a/web/src/classic/components/organisms/Authentication/RootPage/hooks.ts
+++ b/web/src/classic/components/organisms/Authentication/RootPage/hooks.ts
@@ -5,12 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { useAuth, useCleanUrl } from "@reearth/services/auth";
 import { useGetTeamsQuery } from "@reearth/services/gql";
 import { useT } from "@reearth/services/i18n";
-import {
-  useWorkspace,
-  useNotification,
-  useUserId,
-  useSessionWorkspace,
-} from "@reearth/services/state";
+import { useWorkspace, useNotification, useUserId } from "@reearth/services/state";
 
 export type Mode = "layer" | "widget";
 
@@ -19,53 +14,19 @@ export default () => {
   const navigate = useNavigate();
   const { isAuthenticated, isLoading, error: authError, login, logout } = useAuth();
   const [error, isErrorChecked] = useCleanUrl();
-  const [currentWorkspace, setWorkspace] = useSessionWorkspace();
+  const [currentWorkspace, setCurrentWorkspace] = useWorkspace();
   const [currentUserId, setCurrentUserId] = useUserId();
   const [, setNotification] = useNotification();
-  const [lastWorkspace, setLastWorkspace] = useWorkspace();
 
   const { data, loading } = useGetTeamsQuery({ skip: !isAuthenticated });
 
   if (isAuthenticated && !currentUserId) {
     setCurrentUserId(data?.me?.id);
   }
-  useEffect(() => {
-    if (!currentWorkspace && lastWorkspace) setWorkspace(lastWorkspace);
-  }, [currentWorkspace, lastWorkspace, setWorkspace]);
 
   const workspaceId = useMemo(() => {
     return currentWorkspace?.id || data?.me?.myTeam.id;
   }, [currentWorkspace?.id, data?.me?.myTeam.id]);
-
-  const handleRedirect = useCallback(() => {
-    if (currentUserId === data?.me?.id) {
-      setWorkspace(
-        workspaceId
-          ? data?.me?.teams.find(t => t.id === workspaceId) ?? data?.me?.myTeam
-          : undefined,
-      );
-      setLastWorkspace(currentWorkspace);
-
-      navigate(`/dashboard/${workspaceId}`);
-    } else {
-      setCurrentUserId(data?.me?.id);
-      setWorkspace(data?.me?.myTeam);
-      setLastWorkspace(currentWorkspace);
-
-      navigate(`/dashboard/${data?.me?.myTeam.id}`);
-    }
-  }, [
-    currentUserId,
-    data?.me?.id,
-    data?.me?.teams,
-    data?.me?.myTeam,
-    setWorkspace,
-    workspaceId,
-    setLastWorkspace,
-    currentWorkspace,
-    navigate,
-    setCurrentUserId,
-  ]);
 
   const verifySignup = useCallback(
     async (token: string) => {
@@ -103,21 +64,22 @@ export default () => {
     } else if (!isAuthenticated && !isLoading) {
       login();
     } else {
-      if (!data || !workspaceId) return;
-      handleRedirect();
+      if (currentWorkspace || !data || !workspaceId) return;
+      setCurrentWorkspace(data.me?.myTeam);
+      navigate(`/dashboard/${workspaceId}`);
     }
   }, [
     isAuthenticated,
-    login,
     isLoading,
-    verifySignup,
-    navigate,
     currentWorkspace,
-    handleRedirect,
     data,
     isErrorChecked,
     error,
     workspaceId,
+    login,
+    verifySignup,
+    navigate,
+    setCurrentWorkspace,
   ]);
 
   useEffect(() => {

--- a/web/src/classic/components/organisms/EarthEditor/Header/hooks.ts
+++ b/web/src/classic/components/organisms/EarthEditor/Header/hooks.ts
@@ -14,13 +14,7 @@ import {
   useCreateTeamMutation,
 } from "@reearth/services/gql";
 import { useT } from "@reearth/services/i18n";
-import {
-  useSceneId,
-  useWorkspace,
-  useProject,
-  useNotification,
-  useSessionWorkspace,
-} from "@reearth/services/state";
+import { useSceneId, useWorkspace, useProject, useNotification } from "@reearth/services/state";
 
 export default () => {
   const url = window.REEARTH_CONFIG?.published?.split("{}");
@@ -29,9 +23,8 @@ export default () => {
 
   const [, setNotification] = useNotification();
   const [sceneId] = useSceneId();
-  const [currentWorkspace, setWorkspace] = useSessionWorkspace();
   const [currentProject, setProject] = useProject();
-  const [lastWorkspace, setLastWorkspace] = useWorkspace();
+  const [currentWorkspace, setCurrentWorkspace] = useWorkspace();
 
   const navigate = useNavigate();
 
@@ -81,16 +74,6 @@ export default () => {
     },
     [checkProjectAliasQuery, project],
   );
-
-  useEffect(() => {
-    if (!currentWorkspace && lastWorkspace && workspaceId == lastWorkspace.id)
-      setWorkspace(lastWorkspace);
-    else {
-      const workspace = workspaces?.find(workspace => workspace.id === workspaceId);
-      setWorkspace(workspace);
-      setLastWorkspace(workspace);
-    }
-  }, [currentWorkspace, lastWorkspace, setLastWorkspace, setWorkspace, workspaceId, workspaces]);
 
   useEffect(() => {
     setValidAlias(
@@ -171,16 +154,14 @@ export default () => {
   );
 
   const handleTeamChange = useCallback(
-    (workspaceId: string) => {
-      const workspace = workspaces?.find(workspace => workspace.id === workspaceId);
-      if (workspace && workspaceId !== currentWorkspace?.id) {
-        setWorkspace(workspace);
-        setLastWorkspace(currentWorkspace);
-
-        navigate(`/dashboard/${workspaceId}`);
+    (id: string) => {
+      const workspace = workspaces?.find(workspace => workspace.id === id);
+      if (workspace && id !== currentWorkspace?.id) {
+        setCurrentWorkspace(workspace);
+        navigate(`/dashboard/${id}`);
       }
     },
-    [workspaces, currentWorkspace, setWorkspace, setLastWorkspace, navigate],
+    [currentWorkspace?.id, setCurrentWorkspace, workspaces, navigate],
   );
 
   const [createTeamMutation] = useCreateTeamMutation();
@@ -191,13 +172,11 @@ export default () => {
         refetchQueries: ["GetTeams"],
       });
       if (results.data?.createTeam) {
-        setWorkspace(results.data.createTeam.team);
-        setLastWorkspace(results.data.createTeam.team);
-
+        setCurrentWorkspace(results.data.createTeam.team);
         navigate(`/dashboard/${results.data.createTeam.team.id}`);
       }
     },
-    [createTeamMutation, setWorkspace, setLastWorkspace, navigate],
+    [createTeamMutation, setCurrentWorkspace, navigate],
   );
 
   useEffect(() => {

--- a/web/src/classic/components/organisms/EarthEditor/PropertyPane/hooks.ts
+++ b/web/src/classic/components/organisms/EarthEditor/PropertyPane/hooks.ts
@@ -36,7 +36,6 @@ import {
   useSelectedBlock,
   useWidgetAlignEditorActivated,
   useSelectedWidgetArea,
-  useSessionWorkspace,
 } from "@reearth/services/state";
 
 import useQueries, { Mode as RawMode } from "./hooks-queries";
@@ -71,8 +70,7 @@ export default (mode: Mode) => {
   const [isCapturing, onIsCapturingChange] = useIsCapturing();
   const [camera, setCamera] = useCamera();
   const [sceneMode] = useSceneMode();
-  const [workspace] = useSessionWorkspace();
-  const [lastWorkspace] = useWorkspace();
+  const [workspace] = useWorkspace();
 
   const [sceneId] = useSceneId();
   const [widgetAlignEditorActivated, setWidgetAlignEditorActivated] =
@@ -367,7 +365,7 @@ export default (mode: Mode) => {
 
   return {
     pane,
-    workspaceId: workspace?.id ?? lastWorkspace?.id,
+    workspaceId: workspace?.id,
     error,
     loading,
     isLayerGroup,

--- a/web/src/classic/components/organisms/Settings/Account/hooks.ts
+++ b/web/src/classic/components/organisms/Settings/Account/hooks.ts
@@ -3,12 +3,7 @@ import { useCallback } from "react";
 
 import { useUpdateMeMutation, useGetProfileQuery, Theme as GQLTheme } from "@reearth/services/gql";
 import { useT } from "@reearth/services/i18n";
-import {
-  useWorkspace,
-  useProject,
-  useNotification,
-  useSessionWorkspace,
-} from "@reearth/services/state";
+import { useWorkspace, useProject, useNotification } from "@reearth/services/state";
 
 const enumTypeMapper: Partial<Record<GQLTheme, string>> = {
   [GQLTheme.Default]: "default",
@@ -27,9 +22,8 @@ export default () => {
   const t = useT();
   const [, setNotification] = useNotification();
   const client = useApolloClient();
-  const [currentWorkspace] = useSessionWorkspace();
+  const [currentWorkspace] = useWorkspace();
   const [currentProject] = useProject();
-  const [lastWorkspace] = useWorkspace();
 
   const { data: profileData } = useGetProfileQuery();
   const me = profileData?.me;
@@ -101,7 +95,7 @@ export default () => {
   );
 
   return {
-    currentWorkspace: currentWorkspace ?? lastWorkspace,
+    currentWorkspace,
     currentProject,
     me,
     hasPassword,

--- a/web/src/classic/components/organisms/Settings/Project/Dataset/hooks.ts
+++ b/web/src/classic/components/organisms/Settings/Project/Dataset/hooks.ts
@@ -10,12 +10,7 @@ import {
   useDatasetsListQuery,
 } from "@reearth/services/gql";
 import { useT } from "@reearth/services/i18n";
-import {
-  useWorkspace,
-  useProject,
-  useNotification,
-  useSessionWorkspace,
-} from "@reearth/services/state";
+import { useWorkspace, useProject, useNotification } from "@reearth/services/state";
 
 type Nodes = NonNullable<DatasetsListQuery["datasetSchemas"]["nodes"]>;
 
@@ -26,8 +21,7 @@ const datasetPerPage = 20;
 export default (projectId: string) => {
   const t = useT();
   const { getAccessToken } = useAuth();
-  const [currentWorkspace] = useSessionWorkspace();
-  const [lastWorkspace] = useWorkspace();
+  const [currentWorkspace] = useWorkspace();
 
   const [currentProject] = useProject();
   const [, setNotification] = useNotification();
@@ -142,7 +136,7 @@ export default (projectId: string) => {
   );
 
   return {
-    currentWorkspace: currentWorkspace ?? lastWorkspace,
+    currentWorkspace,
     currentProject,
     datasetSchemas,
     datasetLoading: loading ?? isRefetchingDataSets,

--- a/web/src/classic/components/organisms/Settings/Project/Public/hooks.ts
+++ b/web/src/classic/components/organisms/Settings/Project/Public/hooks.ts
@@ -16,7 +16,6 @@ import {
   useNotification,
   NotificationType,
   useCurrentTheme as useCurrentTheme,
-  useSessionWorkspace,
 } from "@reearth/services/state";
 
 type Params = {
@@ -24,8 +23,7 @@ type Params = {
 };
 
 export default ({ projectId }: Params) => {
-  const [currentWorkspace] = useSessionWorkspace();
-  const [lastWorkspace] = useWorkspace();
+  const [currentWorkspace] = useWorkspace();
 
   const [currentProject] = useProject();
   const [, setNotification] = useNotification();
@@ -172,7 +170,7 @@ export default ({ projectId }: Params) => {
   const [currentTheme] = useCurrentTheme();
 
   return {
-    currentWorkspace: currentWorkspace ?? lastWorkspace,
+    currentWorkspace,
     currentProject,
     projectAlias,
     projectStatus: convertStatus(project?.publishmentStatus),

--- a/web/src/classic/components/organisms/Settings/Project/hooks.ts
+++ b/web/src/classic/components/organisms/Settings/Project/hooks.ts
@@ -7,7 +7,7 @@ import {
   useDeleteProjectMutation,
 } from "@reearth/services/gql";
 import { useT } from "@reearth/services/i18n";
-import { useWorkspace, useNotification, useSessionWorkspace } from "@reearth/services/state";
+import { useWorkspace, useNotification } from "@reearth/services/state";
 
 type Params = {
   projectId: string;
@@ -16,8 +16,7 @@ type Params = {
 export default ({ projectId }: Params) => {
   const t = useT();
   const [, setNotification] = useNotification();
-  const [currentWorkspace] = useSessionWorkspace();
-  const [lastWorkspace] = useWorkspace();
+  const [currentWorkspace] = useWorkspace();
 
   const { data } = useGetProjectQuery({
     variables: { projectId: projectId ?? "" },
@@ -133,7 +132,7 @@ export default ({ projectId }: Params) => {
   return {
     project,
     projectId,
-    currentWorkspace: currentWorkspace ?? lastWorkspace,
+    currentWorkspace,
     updateProjectName,
     updateProjectDescription,
     updateProjectImageUrl,

--- a/web/src/classic/components/organisms/Settings/ProjectList/hooks.ts
+++ b/web/src/classic/components/organisms/Settings/ProjectList/hooks.ts
@@ -13,12 +13,7 @@ import {
   GetProjectsQuery,
 } from "@reearth/services/gql";
 import { useT } from "@reearth/services/i18n";
-import {
-  useWorkspace,
-  useProject,
-  useNotification,
-  useSessionWorkspace,
-} from "@reearth/services/state";
+import { useWorkspace, useProject, useNotification } from "@reearth/services/state";
 import { ProjectType } from "@reearth/types";
 
 const toPublishmentStatus = (s: PublishmentStatus) =>
@@ -33,9 +28,8 @@ export type ProjectNodes = NonNullable<GetProjectsQuery["projects"]["nodes"][num
 const projectPerPage = 5;
 
 export default (workspaceId: string) => {
+  const [currentWorkspace, setWorkspace] = useWorkspace();
   const [, setNotification] = useNotification();
-  const [currentWorkspace, setWorkspace] = useSessionWorkspace();
-  const [lastWorkspace, setLastWorkspace] = useWorkspace();
   const [prjectType, setPrjectType] = useState<ProjectType>("classic");
   const [prjTypeSelectOpen, setPrjTypeSelectOpen] = useState(false);
 
@@ -55,10 +49,6 @@ export default (workspaceId: string) => {
     refetchQueries: ["GetProjects"],
   });
   const [createScene] = useCreateSceneMutation();
-
-  useEffect(() => {
-    if (!currentWorkspace && lastWorkspace) setWorkspace(lastWorkspace);
-  }, [currentWorkspace, lastWorkspace, setWorkspace]);
 
   if (currentWorkspace && currentWorkspace.id !== workspaceId) {
     workspaceId = currentWorkspace?.id;
@@ -81,9 +71,8 @@ export default (workspaceId: string) => {
   useEffect(() => {
     if (workspace?.id && !currentWorkspace?.id) {
       setWorkspace(workspace);
-      setLastWorkspace(currentWorkspace);
     }
-  }, [currentWorkspace, workspace, setWorkspace, setLastWorkspace]);
+  }, [currentWorkspace, workspace, setWorkspace]);
 
   const projectNodes = projectData?.projects.edges.map(e => e.node) as ProjectNodes;
 

--- a/web/src/classic/components/organisms/Settings/SettingPage/hooks.ts
+++ b/web/src/classic/components/organisms/Settings/SettingPage/hooks.ts
@@ -9,7 +9,7 @@ import {
   useGetProjectWithSceneIdQuery,
   useCreateTeamMutation,
 } from "@reearth/services/gql";
-import { useWorkspace, useProject, useSessionWorkspace } from "@reearth/services/state";
+import { useWorkspace, useProject } from "@reearth/services/state";
 
 type Params = {
   workspaceId?: string;
@@ -19,19 +19,14 @@ type Params = {
 export default (params: Params) => {
   const projectId = params.projectId;
 
-  const [currentWorkspace, setWorkspace] = useSessionWorkspace();
+  const [currentWorkspace, setWorkspace] = useWorkspace();
   const [currentProject, setProject] = useProject();
-  const [lastWorkspace, setLastWorkspace] = useWorkspace();
 
   const { refetch } = useGetMeQuery();
 
   const navigate = useNavigate();
   const [modalShown, setModalShown] = useState(false);
   const openModal = useCallback(() => setModalShown(true), []);
-
-  useEffect(() => {
-    if (!currentWorkspace && lastWorkspace) setWorkspace(lastWorkspace);
-  }, [currentWorkspace, lastWorkspace, setWorkspace]);
 
   const handleModalClose = useCallback(
     (r?: boolean) => {
@@ -65,7 +60,6 @@ export default (params: Params) => {
           : teamsData?.me?.myTeam ?? undefined,
       );
     }
-    setLastWorkspace(currentWorkspace);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentWorkspace, setWorkspace, workspaces, teamsData?.me]);
 
@@ -97,13 +91,12 @@ export default (params: Params) => {
 
       if (workspace) {
         setWorkspace(workspace);
-        setLastWorkspace(currentWorkspace);
         if (params.projectId) {
           navigate("/settings/account");
         }
       }
     },
-    [workspaces, setWorkspace, setLastWorkspace, currentWorkspace, params.projectId, navigate],
+    [workspaces, setWorkspace, params.projectId, navigate],
   );
 
   const [createTeamMutation] = useCreateTeamMutation();
@@ -116,10 +109,9 @@ export default (params: Params) => {
       const workspace = results.data?.createTeam?.team;
       if (results) {
         setWorkspace(workspace);
-        setLastWorkspace(workspace);
       }
     },
-    [createTeamMutation, setLastWorkspace, setWorkspace],
+    [createTeamMutation, setWorkspace],
   );
 
   return {

--- a/web/src/classic/components/organisms/Settings/Workspace/Asset/hooks.ts
+++ b/web/src/classic/components/organisms/Settings/Workspace/Asset/hooks.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 import assetHooks from "@reearth/classic/components/organisms/Common/AssetContainer/hooks";
-import { useWorkspace, useProject, useSessionWorkspace } from "@reearth/services/state";
+import { useWorkspace, useProject } from "@reearth/services/state";
 
 export type Params = {
   workspaceId: string;
@@ -10,8 +10,7 @@ export type Params = {
 
 export default (params: Params) => {
   const navigate = useNavigate();
-  const [currentWorkspace] = useSessionWorkspace();
-  const [lastWorkspace] = useWorkspace();
+  const [currentWorkspace] = useWorkspace();
 
   const [currentProject] = useProject();
 
@@ -30,13 +29,13 @@ export default (params: Params) => {
 
   useEffect(() => {
     if (params.workspaceId && currentWorkspace?.id && params.workspaceId !== currentWorkspace.id) {
-      navigate(`/settings/workspaces/${currentWorkspace?.id ?? lastWorkspace?.id}/asset`);
+      navigate(`/settings/workspaces/${currentWorkspace?.id}/asset`);
     }
-  }, [params, currentWorkspace, navigate, lastWorkspace?.id]);
+  }, [params, currentWorkspace, navigate]);
 
   return {
     currentProject,
-    currentWorkspace: currentWorkspace ?? lastWorkspace,
+    currentWorkspace,
     assets,
     isLoading,
     hasMoreAssets,

--- a/web/src/classic/components/organisms/Settings/Workspace/hooks.ts
+++ b/web/src/classic/components/organisms/Settings/Workspace/hooks.ts
@@ -15,12 +15,7 @@ import {
 } from "@reearth/services/gql";
 import { Team } from "@reearth/services/gql/graphql-client-api";
 import { useT } from "@reearth/services/i18n";
-import {
-  useWorkspace,
-  useProject,
-  useNotification,
-  useSessionWorkspace,
-} from "@reearth/services/state";
+import { useWorkspace, useProject, useNotification } from "@reearth/services/state";
 
 type Params = {
   workspaceId: string;
@@ -28,8 +23,7 @@ type Params = {
 
 export default (params: Params) => {
   const t = useT();
-  const [currentWorkspace, setWorkspace] = useSessionWorkspace();
-  const [lastWorkspace, setLastWorkspace] = useWorkspace();
+  const [currentWorkspace, setWorkspace] = useWorkspace();
 
   const [currentProject] = useProject();
   const [, setNotification] = useNotification();
@@ -56,10 +50,6 @@ export default (params: Params) => {
     },
     [refetch],
   );
-
-  useEffect(() => {
-    if (!currentWorkspace && lastWorkspace) setWorkspace(lastWorkspace);
-  }, [currentWorkspace, lastWorkspace, setWorkspace]);
 
   useEffect(() => {
     if (params.workspaceId && currentWorkspace?.id && params.workspaceId !== currentWorkspace.id) {
@@ -95,7 +85,6 @@ export default (params: Params) => {
         });
       } else {
         setWorkspace(workspace);
-        setLastWorkspace(workspace);
 
         setNotification({
           type: "success",
@@ -104,7 +93,7 @@ export default (params: Params) => {
       }
       setModalShown(false);
     },
-    [createTeamMutation, setNotification, t, setWorkspace, setLastWorkspace],
+    [createTeamMutation, setNotification, t, setWorkspace],
   );
 
   const [updateTeamMutation] = useUpdateTeamMutation();
@@ -120,7 +109,6 @@ export default (params: Params) => {
         });
       } else {
         setWorkspace(results.data?.updateTeam?.team);
-        setLastWorkspace(currentWorkspace);
 
         setNotification({
           type: "info",
@@ -128,15 +116,7 @@ export default (params: Params) => {
         });
       }
     },
-    [
-      workspaceId,
-      updateTeamMutation,
-      setNotification,
-      t,
-      setWorkspace,
-      setLastWorkspace,
-      currentWorkspace,
-    ],
+    [workspaceId, updateTeamMutation, setNotification, t, setWorkspace],
   );
 
   const [deleteTeamMutation] = useDeleteTeamMutation({
@@ -156,18 +136,8 @@ export default (params: Params) => {
         text: t("Workspace was successfully deleted."),
       });
       setWorkspace(workspaces[0]);
-      setLastWorkspace(currentWorkspace);
     }
-  }, [
-    workspaceId,
-    deleteTeamMutation,
-    setNotification,
-    t,
-    setWorkspace,
-    workspaces,
-    setLastWorkspace,
-    currentWorkspace,
-  ]);
+  }, [workspaceId, deleteTeamMutation, setNotification, t, setWorkspace, workspaces]);
 
   const [addMemberToTeamMutation] = useAddMemberToTeamMutation();
 
@@ -189,7 +159,6 @@ export default (params: Params) => {
             return;
           }
           setWorkspace(workspace);
-          setLastWorkspace(currentWorkspace);
         }),
       );
       if (results) {
@@ -199,15 +168,7 @@ export default (params: Params) => {
         });
       }
     },
-    [
-      workspaceId,
-      addMemberToTeamMutation,
-      setWorkspace,
-      setLastWorkspace,
-      currentWorkspace,
-      setNotification,
-      t,
-    ],
+    [workspaceId, addMemberToTeamMutation, setWorkspace, setNotification, t],
   );
 
   const [updateMemberOfTeamMutation] = useUpdateMemberOfTeamMutation();
@@ -229,11 +190,10 @@ export default (params: Params) => {
         const workspace = results.data?.updateMemberOfTeam?.team;
         if (workspace) {
           setWorkspace(workspace);
-          setLastWorkspace(currentWorkspace);
         }
       }
     },
-    [workspaceId, updateMemberOfTeamMutation, setWorkspace, setLastWorkspace, currentWorkspace],
+    [workspaceId, updateMemberOfTeamMutation, setWorkspace],
   );
 
   const [removeMemberFromTeamMutation] = useRemoveMemberFromTeamMutation();
@@ -254,34 +214,24 @@ export default (params: Params) => {
         return;
       }
       setWorkspace(workspace);
-      setLastWorkspace(currentWorkspace);
 
       setNotification({
         type: "success",
         text: t("Successfully removed member from the workspace."),
       });
     },
-    [
-      workspaceId,
-      removeMemberFromTeamMutation,
-      setWorkspace,
-      setLastWorkspace,
-      currentWorkspace,
-      setNotification,
-      t,
-    ],
+    [workspaceId, removeMemberFromTeamMutation, setWorkspace, setNotification, t],
   );
 
   const selectWorkspace = useCallback(
     (workspace: Team) => {
       if (workspace.id) {
         setWorkspace(workspace);
-        setLastWorkspace(currentWorkspace);
 
         navigate(`/settings/workspaces/${workspace.id}`);
       }
     },
-    [currentWorkspace, navigate, setLastWorkspace, setWorkspace],
+    [navigate, setWorkspace],
   );
 
   return {

--- a/web/src/services/state/index.ts
+++ b/web/src/services/state/index.ts
@@ -1,6 +1,5 @@
 import { atom, useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
-import { SyncStorage } from "jotai/utils/atomWithStorage";
 
 import { Clock } from "@reearth/classic/components/molecules/Visualizer/Plugin/types";
 import { LayerSelectionReason } from "@reearth/classic/core/Map";
@@ -96,31 +95,8 @@ export type Workspace = {
   policy?: Policy | null;
 };
 
-const workspace = atomWithStorage<Workspace | undefined>("workspace", undefined);
+const workspace = atom<Workspace | undefined>(undefined);
 export const useWorkspace = () => useAtom(workspace);
-
-const sessionStorageObj: SyncStorage<Workspace | undefined> = {
-  getItem: key => {
-    const value = sessionStorage.getItem(key);
-    if (value === null) {
-      return undefined;
-    }
-    return JSON.parse(value) as Workspace;
-  },
-  setItem: (key, value) => {
-    sessionStorage.setItem(key, JSON.stringify(value));
-  },
-  removeItem: function (): void {
-    throw new Error("Function not implemented.");
-  },
-};
-
-const sessionWorkspace = atomWithStorage<Workspace | undefined>(
-  "lastWorkspace",
-  undefined,
-  sessionStorageObj,
-);
-export const useSessionWorkspace = () => useAtom(sessionWorkspace);
 
 const userId = atomWithStorage<string | undefined>("userId", undefined);
 export const useUserId = () => useAtom(userId);


### PR DESCRIPTION
# Overview
We were getting an infinite loop on the Dashboard that was hurting the server (probably).
The logic around remembering the previous workspace was hard to understand and maintain, so I decided to remove that implementation so we can get Re:Earth back to a working condition and then reimplement that functionality later.