### PR TITLE
feat(web): visualizer supports shadow map

### DIFF
--- a/web/src/beta/lib/core/Map/types/index.ts
+++ b/web/src/beta/lib/core/Map/types/index.ts
@@ -288,6 +288,9 @@ export type SceneProperty = {
     ground_atmosphere?: boolean;
     sky_atmosphere?: boolean;
     shadows?: boolean;
+    shadowResolution?: 1024 | 2048 | 4096;
+    softShadow?: boolean;
+    shadowDarkness?: number;
     fog?: boolean;
     fog_density?: number;
     brightness_shift?: number;

--- a/web/src/beta/lib/core/engines/Cesium/hooks.ts
+++ b/web/src/beta/lib/core/engines/Cesium/hooks.ts
@@ -132,6 +132,19 @@ export default ({
     property?.light?.lightIntensity,
   ]);
 
+  // shadow map
+  useEffect(() => {
+    const shadowMap = cesium?.current?.cesiumElement?.shadowMap;
+    if (!shadowMap) return;
+    shadowMap.softShadows = property?.atmosphere?.softShadow ?? false;
+    shadowMap.darkness = property?.atmosphere?.shadowDarkness ?? 0.5;
+    shadowMap.size = property?.atmosphere?.shadowResolution ?? 2048;
+  }, [
+    property?.atmosphere?.softShadow,
+    property?.atmosphere?.shadowDarkness,
+    property?.atmosphere?.shadowResolution,
+  ]);
+
   useEffect(() => {
     engineAPI.changeSceneMode(property?.default?.sceneMode, 0);
   }, [property?.default?.sceneMode, engineAPI]);

--- a/web/src/beta/lib/core/engines/Cesium/hooks.ts
+++ b/web/src/beta/lib/core/engines/Cesium/hooks.ts
@@ -154,6 +154,9 @@ export default ({
     shadowMap.softShadows = property?.atmosphere?.softShadow ?? false;
     shadowMap.darkness = property?.atmosphere?.shadowDarkness ?? 0.3;
     shadowMap.size = property?.atmosphere?.shadowResolution ?? 2048;
+    shadowMap.fadingEnabled = true;
+    shadowMap.maximumDistance = 5000;
+    shadowMap.normalOffset = true;
 
     // bias
     const defaultTerrainBias: ShadowMapBias = {

--- a/web/src/beta/lib/core/engines/Cesium/hooks.ts
+++ b/web/src/beta/lib/core/engines/Cesium/hooks.ts
@@ -137,7 +137,7 @@ export default ({
     const shadowMap = cesium?.current?.cesiumElement?.shadowMap;
     if (!shadowMap) return;
     shadowMap.softShadows = property?.atmosphere?.softShadow ?? false;
-    shadowMap.darkness = property?.atmosphere?.shadowDarkness ?? 0.5;
+    shadowMap.darkness = property?.atmosphere?.shadowDarkness ?? 0.3;
     shadowMap.size = property?.atmosphere?.shadowResolution ?? 2048;
   }, [
     property?.atmosphere?.softShadow,

--- a/web/src/beta/lib/core/engines/Cesium/hooks.ts
+++ b/web/src/beta/lib/core/engines/Cesium/hooks.ts
@@ -12,7 +12,7 @@ import {
   SunLight,
   DirectionalLight,
 } from "cesium";
-import type { Viewer as CesiumViewer } from "cesium";
+import type { Viewer as CesiumViewer, ShadowMap } from "cesium";
 import CesiumDnD, { Context } from "cesium-dnd";
 import { isEqual } from "lodash-es";
 import { RefObject, useCallback, useEffect, useMemo, useRef } from "react";
@@ -133,12 +133,56 @@ export default ({
   ]);
 
   // shadow map
+  type ShadowMapBias = {
+    polygonOffsetFactor: number;
+    polygonOffsetUnits: number;
+    normalOffsetScale: number;
+    normalShading: boolean;
+    normalShadingSmooth: number;
+    depthBias: number;
+  };
+
   useEffect(() => {
-    const shadowMap = cesium?.current?.cesiumElement?.shadowMap;
+    const shadowMap = cesium?.current?.cesiumElement?.shadowMap as
+      | (ShadowMap & {
+          _terrainBias: ShadowMapBias;
+          _pointBias: ShadowMapBias;
+          _primitiveBias: ShadowMapBias;
+        })
+      | undefined;
     if (!shadowMap) return;
     shadowMap.softShadows = property?.atmosphere?.softShadow ?? false;
     shadowMap.darkness = property?.atmosphere?.shadowDarkness ?? 0.3;
     shadowMap.size = property?.atmosphere?.shadowResolution ?? 2048;
+
+    // bias
+    const defaultTerrainBias: ShadowMapBias = {
+      polygonOffsetFactor: 1.1,
+      polygonOffsetUnits: 4.0,
+      normalOffsetScale: 0.5,
+      normalShading: true,
+      normalShadingSmooth: 0.3,
+      depthBias: 0.0001,
+    };
+    const defaultPrimitiveBias: ShadowMapBias = {
+      polygonOffsetFactor: 1.1,
+      polygonOffsetUnits: 4.0,
+      normalOffsetScale: 0.1 * 100,
+      normalShading: true,
+      normalShadingSmooth: 0.05,
+      depthBias: 0.00002 * 10,
+    };
+    const defaultPointBias: ShadowMapBias = {
+      polygonOffsetFactor: 1.1,
+      polygonOffsetUnits: 4.0,
+      normalOffsetScale: 0.0,
+      normalShading: true,
+      normalShadingSmooth: 0.1,
+      depthBias: 0.0005,
+    };
+    Object.assign(shadowMap._terrainBias, defaultTerrainBias);
+    Object.assign(shadowMap._primitiveBias, defaultPrimitiveBias);
+    Object.assign(shadowMap._pointBias, defaultPointBias);
   }, [
     property?.atmosphere?.softShadow,
     property?.atmosphere?.shadowDarkness,


### PR DESCRIPTION
# Overview

Add shadow map support for beta.

## What I've done

add:
```ts
type SceneProperty = {
  atmosphere?: {
    // ...
    shadowResolution?: 1024 | 2048 | 4096,
    softShadow?: boolean,
    shadowDarkness?: number,
  };
};
```

## What I haven't done

## How I tested

```js
let layerId = reearth.layers.add({
  type: "simple",
  data: {
    type: "3dtiles",
    url: "https://assets.cms.plateau.reearth.io/assets/11/6d05db-ed47-4f88-b565-9eb385b1ebb0/13100_tokyo23-ku_2022_3dtiles%20_1_1_op_bldg_13101_chiyoda-ku_lod1/tileset.json",
  },
  "3dtiles": {
      pbr: false
  }
});

setTimeout(()=>{
    reearth.camera.flyTo(layerId);

    reearth.scene.overrideProperty({
        atmosphere:{
            shadows: true,
            shadowResolution: 4096,
            softShadow: true,
            shadowDarkness: 0.3
        },
        terrain:{
            terrain: true,
        }
    });
},0);
```

## Which point I want you to review particularly

## Memo
