### PR TITLE
fix(web): infinite loop on network error

### DIFF
--- a/web/src/services/gql/provider.tsx
+++ b/web/src/services/gql/provider.tsx
@@ -10,7 +10,6 @@ import type { ReactNode } from "react";
 import { reportError } from "@reearth/sentry";
 import { useAuth } from "@reearth/services/auth";
 import { e2eAccessToken } from "@reearth/services/config";
-import { useError } from "@reearth/services/state";
 
 import fragmentMatcher from "./fragmentMatcher.json";
 
@@ -51,7 +50,6 @@ const Provider: React.FC<{ children?: ReactNode }> = ({ children }) => {
   const endpoint = window.REEARTH_CONFIG?.api
     ? `${window.REEARTH_CONFIG.api}/graphql`
     : "/api/graphql";
-  const [, setError] = useError();
   const { getAccessToken } = useAuth();
 
   const authLink = setContext(async (_, { headers }) => {
@@ -83,7 +81,6 @@ const Provider: React.FC<{ children?: ReactNode }> = ({ children }) => {
       };
     }
     if (error) {
-      setError(error);
       reportError(error);
     }
   });


### PR DESCRIPTION
# Overview
An infinite loop would happen on an Apollo Client networking error. Turns out this was due to using Jotai state inside our GQL provider for the error message to be shown in our Notification component.

## What I've done
- Fixed the infinite loop

## What I haven't done
- We lose user-facing error messages for GQL (both networking errors and gql errors, which includes policy errors). This PR doesn't include adding error handling directly in the components whose query/mutation can cause these sorts of errors.

## How I tested

## Which point I want you to review particularly

## Memo
Later need to create an error handling policy around GQL and implement it on each query/mutation