### PR TITLE
ci(server): update goreleaser.yml, remove depreciated methods

### DIFF
--- a/server/.goreleaser.yml
+++ b/server/.goreleaser.yml
@@ -13,14 +13,18 @@ builds:
       - -buildid=
     env:
       - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-    replacements:
-      darwin: darwin
-      linux: linux
-      windows: windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{ .Version .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
# Overview
This PR refactor `goreleaser.yml` as it utilizes depreciated method like `replacements` for name_template.

ref: https://goreleaser.com/deprecations/#expired-deprecation-notices_1
