### PR TITLE
fix(web): pass ion token to each layer

### DIFF
--- a/web/src/classic/components/molecules/Visualizer/index.tsx
+++ b/web/src/classic/components/molecules/Visualizer/index.tsx
@@ -232,6 +232,7 @@ export default function Visualizer({
               sceneProperty={overriddenSceneProperty}
               pluginBaseUrl={pluginBaseUrl}
               selectedLayerId={selectedLayerId}
+              meta={engineMeta}
               layers={layers}
               isLayerHidden={isLayerHidden}
               overriddenProperties={layerOverriddenProperties}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -82,6 +82,10 @@ function config(): Plugin {
         {
           api: "http://localhost:8080/api",
           published: "/published.html?alias={}",
+          // If Cesium version is outdated, you can set Ion token as environment variables written at here.
+          // ex: `CESIUM_ION_ACCESS_TOKEN="ION_TOKEN" yarn start`
+          // ref: https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Core/Ion.js#L6-L7
+          cesiumIonAccessToken: process.env.CESIUM_ION_ACCESS_TOKEN,
           ...readEnv("REEARTH_WEB", {
             source: loadEnv(
               server.config.mode,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -82,7 +82,7 @@ function config(): Plugin {
         {
           api: "http://localhost:8080/api",
           published: "/published.html?alias={}",
-          // If Cesium version is outdated, you can set Ion token as environment variables written at here.
+          // If Cesium version becomes outdated, you can set the Ion token as an environment variables here.
           // ex: `CESIUM_ION_ACCESS_TOKEN="ION_TOKEN" yarn start`
           // ref: https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Core/Ion.js#L6-L7
           cesiumIonAccessToken: process.env.CESIUM_ION_ACCESS_TOKEN,


### PR DESCRIPTION
# Overview

## What I've done

- Fixed the problem that OSM building is not displayed.
- Fixed to be able to set Cesium ion token in local easily.
```sh
CESIUM_ION_ACCESS_TOKEN="ION_TOKEN" yarn start
```

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
