### PR TITLE
chore(web): allow reearth_config.json to be set remotely for local development

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -85,7 +85,11 @@ function config(): Plugin {
           // If Cesium version becomes outdated, you can set the Ion token as an environment variables here.
           // ex: `CESIUM_ION_ACCESS_TOKEN="ION_TOKEN" yarn start`
           // ref: https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Core/Ion.js#L6-L7
-          cesiumIonAccessToken: process.env.CESIUM_ION_ACCESS_TOKEN,
+          cesiumIonAccessToken:
+            process.env.CESIUM_ION_ACCESS_TOKEN ||
+            // Use test env's cesiumIonAccessToken if possible.
+            (await (await fetch("https://test.reearth.dev/reearth_config.json")).json())
+              .cesiumIonAccessToken,
           ...readEnv("REEARTH_WEB", {
             source: loadEnv(
               server.config.mode,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -83,19 +83,20 @@ function config(): Plugin {
         server.config.envDir ?? process.cwd(),
         server.config.envPrefix,
       );
-      const reearthConfigUrl = envs.REEARTH_WEB_CONFIG_URL;
-      const remoteReearthConfig = reearthConfigUrl
-        ? await (await fetch(reearthConfigUrl)).json()
+      const remoteReearthConfig = envs.REEARTH_WEB_CONFIG_URL
+        ? await (await fetch(envs.REEARTH_WEB_CONFIG_URL)).json()
         : {};
       const configRes = JSON.stringify(
         {
+          ...remoteReearthConfig,
           api: "http://localhost:8080/api",
           published: "/published.html?alias={}",
           // If Cesium version becomes outdated, you can set the Ion token as an environment variables here.
           // ex: `CESIUM_ION_ACCESS_TOKEN="ION_TOKEN" yarn start`
           // ref: https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Core/Ion.js#L6-L7
-          cesiumIonAccessToken:
-            process.env.CESIUM_ION_ACCESS_TOKEN || remoteReearthConfig.cesiumIonAccessToken,
+          ...(process.env.CESIUM_ION_ACCESS_TOKEN
+            ? { cesiumIonAccessToken: process.env.CESIUM_ION_ACCESS_TOKEN }
+            : {}),
           ...readEnv("REEARTH_WEB", {
             source: envs,
           }),


### PR DESCRIPTION
# Overview

You can specify the remote reearth config through an environment variable for development in local env.
```
REEARTH_WEB_CONFIG_URL="URL for ReEarth config"
```

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
