### PR TITLE
feat(web): visualizer antialiasing

### DIFF
--- a/web/src/beta/lib/core/Map/types/index.ts
+++ b/web/src/beta/lib/core/Map/types/index.ts
@@ -326,6 +326,9 @@ export type SceneProperty = {
     lightColor?: string;
     lightIntensity?: number;
   };
+  render?: {
+    antialias?: "low" | "medium" | "high" | "extreme";
+  };
 };
 
 export type EngineComponent = ForwardRefExoticComponent<

--- a/web/src/beta/lib/core/engines/Cesium/hooks.ts
+++ b/web/src/beta/lib/core/engines/Cesium/hooks.ts
@@ -703,6 +703,21 @@ export default ({
     cesium.current.cesiumElement.scene.screenSpaceCameraController.enableZoom = allowCameraZoom;
   }, [featureFlags]);
 
+  // Anti-aliasing
+  useEffect(() => {
+    const viewer = cesium.current?.cesiumElement;
+    if (!viewer || viewer.isDestroyed()) return;
+    viewer.scene.postProcessStages.fxaa.enabled = property?.render?.antialias === "high";
+    viewer.scene.msaaSamples =
+      property?.render?.antialias === "extreme"
+        ? 8
+        : property?.render?.antialias === "high"
+        ? 0
+        : property?.render?.antialias === "medium"
+        ? 4
+        : 1; // default as 1
+  }, [property?.render?.antialias]);
+
   return {
     backgroundColor,
     cesium,


### PR DESCRIPTION
# Overview

Add antialias options to scene property (for beta).

## What I've done

I added `render.antialias` since all scene properties are organized by groups.

```ts
type SceneProperty = {
  // ...
  render?: {
    // low: msaaSamples = 1
    // medium: msaaSamples = 4
    // heigh: enable fxaa
    // extreme: msaaSamples = 8
    antialias: "low" | "medium" | "high" | "extreme";
  }
};
```

## What I haven't done

## How I tested

```js
let layerId = reearth.layers.add({
  type: "simple",
  data: {
    type: "3dtiles",
    url: "https://assets.cms.plateau.reearth.io/assets/11/6d05db-ed47-4f88-b565-9eb385b1ebb0/13100_tokyo23-ku_2022_3dtiles%20_1_1_op_bldg_13101_chiyoda-ku_lod1/tileset.json",
  },
  "3dtiles": {
      pbr: false
  }
});
setTimeout(()=>{
  reearth.camera.flyTo(layerId);
},0);
```

```js
reearth.scene.overrideProperty({
    render: {
        antialias: "medium"
    }
})
```

## Which point I want you to review particularly

## Memo
