### PR TITLE
chore(web): remove duplication from canvas convert.ts

### DIFF
--- a/web/src/classic/components/organisms/EarthEditor/CanvasArea/convert.ts
+++ b/web/src/classic/components/organisms/EarthEditor/CanvasArea/convert.ts
@@ -53,24 +53,6 @@ export type RawLayer = EarthLayerCommonFragment &
       }
   );
 
-export type { Layer } from "@reearth/classic/components/molecules/Visualizer";
-
-// export type RawLayer =
-//   | (EarthLayerItemFragment & EarthLayerCommonFragment)
-//   | ({
-//     __typename: "LayerGroup";
-//     layers?: RawLayer[] | null | undefined;
-//   } & EarthLayerCommonFragment);
-
-export type RawLayer = EarthLayerCommonFragment &
-  (
-    | EarthLayerItemFragment
-    | {
-        __typename: "LayerGroup";
-        layers?: RawLayer[] | null | undefined;
-      }
-  );
-
 type BlockType = Item & {
   pluginId: string;
   extensionId: string;


### PR DESCRIPTION
# Overview
This PR attempts to remove duplication of layer and RawLayer from cavasArea's `convert.ts` file which is causing type errors.
