### PR TITLE
ci(web): increase old-space-size for Node in build-web

### DIFF
--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -27,6 +27,8 @@ jobs:
       run:
         working-directory: web
     if: github.event.inputs.name
+    env:
+      NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - ci-web
       - ci-collect-info
     runs-on: ubuntu-latest
-    if: ${{!failure() && needs.ci-web.result == 'success' && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))}}
+    if: !failure() && needs.ci-web.result == 'success' 
     steps:
       - name: Dispatch Web Build
         uses: benc-uk/workflow-dispatch@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - ci-web
       - ci-collect-info
     runs-on: ubuntu-latest
-    if: !failure() && needs.ci-web.result == 'success' 
+    if: ${{!failure() && needs.ci-web.result == 'success' && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'ci/'))}}
     steps:
       - name: Dispatch Web Build
         uses: benc-uk/workflow-dispatch@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - ci-web
       - ci-collect-info
     runs-on: ubuntu-latest
-    if: ${{!failure() && needs.ci-web.result == 'success'}}
+    if: ${{!failure() && needs.ci-web.result == 'success' && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/'))}}
     steps:
       - name: Dispatch Web Build
         uses: benc-uk/workflow-dispatch@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - ci-web
       - ci-collect-info
     runs-on: ubuntu-latest
-    if: !failure() && needs.ci-web.result == 'success' 
+    if: ${{!failure() && needs.ci-web.result == 'success' && github.event_name == 'push'}}
     steps:
       - name: Dispatch Web Build
         uses: benc-uk/workflow-dispatch@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - ci-web
       - ci-collect-info
     runs-on: ubuntu-latest
-    if: ${{!failure() && needs.ci-web.result == 'success' && github.event_name == 'push'}}
+    if: ${{!failure() && needs.ci-web.result == 'success'}}
     steps:
       - name: Dispatch Web Build
         uses: benc-uk/workflow-dispatch@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - ci-web
       - ci-collect-info
     runs-on: ubuntu-latest
-    if: ${{!failure() && needs.ci-web.result == 'success' && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'release' || startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'ci/'))}}
+    if: !failure() && needs.ci-web.result == 'success' 
     steps:
       - name: Dispatch Web Build
         uses: benc-uk/workflow-dispatch@v1


### PR DESCRIPTION
# Overview
This PR attempts to fix an issue observed with `build-web` action failing due to lack of memory.
