### PR TITLE
feat(web): add VisualizerContext in NLS for beta

### DIFF
--- a/web/src/beta/features/Editor/Visualizer/CanvasArea/hooks.ts
+++ b/web/src/beta/features/Editor/Visualizer/CanvasArea/hooks.ts
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useCallback } from "react";
+import { useMemo, useEffect, useCallback, useState } from "react";
 
 import type { Alignment, Location } from "@reearth/beta/lib/core/Crust";
 import type { LatLng, Tag, ValueTypes, ComputedLayer } from "@reearth/beta/lib/core/mantle";
@@ -31,6 +31,11 @@ export default ({ sceneId, isBuilt }: { sceneId?: string; isBuilt?: boolean }) =
   const [selectedWidgetArea, selectWidgetArea] = useSelectedWidgetArea();
   const [widgetAlignEditorActivated] = useWidgetAlignEditorActivated();
   const [zoomedLayerId, zoomToLayer] = useZoomedLayerId();
+
+  const [isVisualizerReady, setIsVisualizerReady] = useState(false);
+  const handleMount = useCallback(() => {
+    setIsVisualizerReady(true);
+  }, []);
 
   const onBlockMove = useCallback(
     async (_id: string, _fromIndex: number, _toIndex: number) => {
@@ -217,6 +222,7 @@ export default ({ sceneId, isBuilt }: { sceneId?: string; isBuilt?: boolean }) =
     engineMeta,
     layerSelectionReason,
     useExperimentalSandbox,
+    isVisualizerReady,
     selectLayer,
     selectBlock,
     onBlockChange,
@@ -231,5 +237,6 @@ export default ({ sceneId, isBuilt }: { sceneId?: string; isBuilt?: boolean }) =
     onFovChange,
     handleDropLayer,
     zoomToLayer,
+    handleMount,
   };
 };

--- a/web/src/beta/features/Editor/Visualizer/CanvasArea/index.tsx
+++ b/web/src/beta/features/Editor/Visualizer/CanvasArea/index.tsx
@@ -35,6 +35,7 @@ const CanvasArea: React.FC<Props> = ({ sceneId, isBuilt, inEditor }) => {
     engineMeta,
     layerSelectionReason,
     useExperimentalSandbox,
+    isVisualizerReady: _isVisualizerReady,
     selectLayer,
     selectBlock,
     onBlockChange,
@@ -49,6 +50,7 @@ const CanvasArea: React.FC<Props> = ({ sceneId, isBuilt, inEditor }) => {
     onFovChange,
     handleDropLayer,
     zoomToLayer,
+    handleMount,
   } = useHooks({ sceneId, isBuilt });
   const renderInfoboxInsertionPopUp = useCallback<
     NonNullable<VisualizerProps["renderInfoboxInsertionPopup"]>
@@ -99,6 +101,7 @@ const CanvasArea: React.FC<Props> = ({ sceneId, isBuilt, inEditor }) => {
         onBlockInsert={onBlockInsert}
         onLayerDrop={handleDropLayer}
         onZoomToLayer={zoomToLayer}
+        onMount={handleMount}
         renderInfoboxInsertionPopup={renderInfoboxInsertionPopUp}
       />
       <FovSlider

--- a/web/src/beta/lib/core/Map/types/index.ts
+++ b/web/src/beta/lib/core/Map/types/index.ts
@@ -132,6 +132,7 @@ export type EngineProps = {
     position: LatLng | undefined,
   ) => void;
   onLayerEdit?: (e: LayerEditEvent) => void;
+  onMount?: () => void;
 };
 
 export type LayerEditEvent = {

--- a/web/src/beta/lib/core/README.md
+++ b/web/src/beta/lib/core/README.md
@@ -5,3 +5,15 @@
 - **Map**: Engine + mantle
 
 ![Architecture](docs/architecture.svg)
+
+## Context
+
+We have some type of the context to expose the interface for the map API. The map API is the abstracted map engine API. For example, we are using Cesium as the map engine, but we have a plan to support another map engine in the future. To do this, we define the interface as the map API. The map API is abstracted as MapRef internally. The MapRef has two type of API for now. First one is EngineRef that is API to access to the map engine's API. And second one is LayersRef that is API to access to the abstracted layer system. This manages the data to display for the map engine.
+
+We have the context as the follows.
+
+- FeatureContext ... It works as the interface for exposing the map API to the Feature components and the Layers component.
+- WidgetContext ... It works as the interface for exposing the map API to the Widget components.
+- VisualizerContext ... It works as the interface for exposing the map API to Visualizer.
+
+By defining these context as the interface, we can understand which API for the map API is used in each layer. And if there are some features of the map API depends on the layer, we can absorb the feature in the context.

--- a/web/src/beta/lib/core/Visualizer/context.tsx
+++ b/web/src/beta/lib/core/Visualizer/context.tsx
@@ -1,0 +1,27 @@
+import { FC, PropsWithChildren, RefObject, createContext, useContext, useMemo } from "react";
+
+import { Ref as MapRef } from "../Map";
+
+const context = createContext<RefObject<MapRef> | undefined>(undefined);
+
+export type Context = RefObject<MapRef>;
+
+export const useVisualizer = (): RefObject<MapRef> => {
+  const value = useContext(context);
+  if (!value) {
+    throw new Error("Visualizer is not declared. You have to use this hook inside of Visualizer");
+  }
+  return value;
+};
+
+const filterMapRefToContext = (mapRef: RefObject<MapRef>): Context => {
+  return mapRef as Context;
+};
+
+export const VisualizerProvider: FC<PropsWithChildren<{ mapRef: RefObject<MapRef> }>> = ({
+  mapRef,
+  children,
+}) => {
+  const value = useMemo(() => filterMapRefToContext(mapRef), [mapRef]);
+  return <context.Provider value={value}>{children}</context.Provider>;
+};

--- a/web/src/beta/lib/core/Visualizer/hooks.ts
+++ b/web/src/beta/lib/core/Visualizer/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Ref, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { useWindowSize } from "react-use";
 
 // TODO: Move these utils
@@ -24,43 +24,48 @@ import useViewport from "./useViewport";
 
 const viewportMobileMaxWidth = 768;
 
-export default function useHooks({
-  selectedBlockId: initialSelectedBlockId,
-  camera: initialCamera,
-  interactionMode: initialInteractionMode,
-  sceneProperty,
-  isEditable,
-  rootLayerId,
-  zoomedLayerId,
-  ownBuiltinWidgets,
-  onLayerSelect,
-  onBlockSelect,
-  onCameraChange,
-  onInteractionModeChange,
-  onZoomToLayer,
-  onLayerDrop,
-}: {
-  selectedBlockId?: string;
-  camera?: Camera;
-  interactionMode?: InteractionModeType;
-  isEditable?: boolean;
-  rootLayerId?: string;
-  sceneProperty?: SceneProperty;
-  zoomedLayerId?: string;
-  ownBuiltinWidgets?: (keyof BuiltinWidgets)[];
-  onLayerSelect?: (
-    layerId: string | undefined,
-    featureId: string | undefined,
-    layer: (() => Promise<ComputedLayer | undefined>) | undefined,
-    reason: LayerSelectionReason | undefined,
-  ) => void;
-  onBlockSelect?: (blockId?: string) => void;
-  onCameraChange?: (camera: Camera) => void;
-  onInteractionModeChange?: (mode: InteractionModeType) => void;
-  onZoomToLayer?: (layerId: string | undefined) => void;
-  onLayerDrop?: (layerId: string, propertyKey: string, position: LatLng | undefined) => void;
-}) {
+export default function useHooks(
+  {
+    selectedBlockId: initialSelectedBlockId,
+    camera: initialCamera,
+    interactionMode: initialInteractionMode,
+    sceneProperty,
+    isEditable,
+    rootLayerId,
+    zoomedLayerId,
+    ownBuiltinWidgets,
+    onLayerSelect,
+    onBlockSelect,
+    onCameraChange,
+    onInteractionModeChange,
+    onZoomToLayer,
+    onLayerDrop,
+  }: {
+    selectedBlockId?: string;
+    camera?: Camera;
+    interactionMode?: InteractionModeType;
+    isEditable?: boolean;
+    rootLayerId?: string;
+    sceneProperty?: SceneProperty;
+    zoomedLayerId?: string;
+    ownBuiltinWidgets?: (keyof BuiltinWidgets)[];
+    onLayerSelect?: (
+      layerId: string | undefined,
+      featureId: string | undefined,
+      layer: (() => Promise<ComputedLayer | undefined>) | undefined,
+      reason: LayerSelectionReason | undefined,
+    ) => void;
+    onBlockSelect?: (blockId?: string) => void;
+    onCameraChange?: (camera: Camera) => void;
+    onInteractionModeChange?: (mode: InteractionModeType) => void;
+    onZoomToLayer?: (layerId: string | undefined) => void;
+    onLayerDrop?: (layerId: string, propertyKey: string, position: LatLng | undefined) => void;
+  },
+  ref: Ref<MapRef | null>,
+) {
   const mapRef = useRef<MapRef>(null);
+
+  useImperativeHandle(ref, () => mapRef.current, []);
 
   const wrapperRef = useRef<HTMLDivElement>(null);
 

--- a/web/src/beta/lib/core/Visualizer/index.stories.tsx
+++ b/web/src/beta/lib/core/Visualizer/index.stories.tsx
@@ -1,67 +1,126 @@
-import { Meta, Story } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
+import { ComponentProps, FC, useEffect, useState } from "react";
 
-import Component, { Props } from ".";
+import { useVisualizer } from "./context";
+
+import Component from ".";
 
 export default {
   component: Component,
-  parameters: { actions: { argTypesRegex: "^on.*" } },
 } as Meta;
 
-const Template: Story<Props> = args => <Component {...args} />;
+type Story = StoryObj<typeof Component>;
 
-export const Cesium = Template.bind({});
-
-Cesium.args = {
-  ready: true,
-  engine: "cesium",
-  sceneProperty: {
-    tiles: [
-      {
-        id: "default",
-        tile_type: "default",
-      },
-    ],
+export const Cesium: Story = {
+  args: {
+    ready: true,
+    engine: "cesium",
+    sceneProperty: {
+      tiles: [
+        {
+          id: "default",
+          tile_type: "default",
+        },
+      ],
+    },
   },
 };
 
-export const Plugin = Template.bind({});
-
-Plugin.args = {
-  ready: true,
-  engine: "cesium",
-  sceneProperty: {
-    tiles: [
-      {
-        id: "default",
-        tile_type: "default",
+const Content: FC<{ ready?: boolean }> = ({ ready }) => {
+  const visualizer = useVisualizer();
+  useEffect(() => {
+    if (!ready) return;
+    visualizer.current?.engine.flyTo({
+      lat: 35.683252649879606,
+      lng: 139.75262379931652,
+      height: 5000,
+    });
+    visualizer.current?.layers.add({
+      type: "simple",
+      data: {
+        type: "geojson",
+        value: {
+          // GeoJSON
+          type: "Feature",
+          geometry: {
+            coordinates: [139.75262379931652, 35.683252649879606, 1000],
+            type: "Point",
+          },
+        },
       },
-    ],
+      marker: {
+        imageColor: "blue",
+      },
+    });
+  }, [visualizer, ready]);
+  return null;
+};
+
+const VisualizerWrapper: FC<ComponentProps<typeof Component>> = props => {
+  const [ready, setReady] = useState(false);
+  return (
+    <Component {...props} onMount={() => setReady(true)}>
+      <Content ready={ready} />
+    </Component>
+  );
+};
+
+export const API: Story = {
+  render: args => {
+    return <VisualizerWrapper {...args} />;
   },
-  widgetAlignSystem: {
-    outer: {
-      left: {
-        top: {
-          align: "start",
-          widgets: [
-            {
-              id: "plugin",
-              pluginId: "plugin",
-              extensionId: "test",
-              ...({
-                __REEARTH_SOURCECODE: `reearth.layers.add(${JSON.stringify({
-                  id: "l",
-                  type: "simple",
-                  data: {
-                    type: "geojson",
-                    value: { type: "Feature", geometry: { type: "Point", coordinates: [0, 0] } },
-                  },
-                  marker: {
-                    imageColor: "#fff",
-                  },
-                })});`,
-              } as any),
-            },
-          ],
+  args: {
+    ready: true,
+    engine: "cesium",
+    sceneProperty: {
+      tiles: [
+        {
+          id: "default",
+          tile_type: "default",
+        },
+      ],
+    },
+  },
+};
+
+export const Plugin = {
+  args: {
+    ready: true,
+    engine: "cesium",
+    sceneProperty: {
+      tiles: [
+        {
+          id: "default",
+          tile_type: "default",
+        },
+      ],
+    },
+    widgetAlignSystem: {
+      outer: {
+        left: {
+          top: {
+            align: "start",
+            widgets: [
+              {
+                id: "plugin",
+                pluginId: "plugin",
+                extensionId: "test",
+                ...({
+                  __REEARTH_SOURCECODE: `reearth.layers.add(${JSON.stringify({
+                    id: "l",
+                    type: "simple",
+                    data: {
+                      type: "geojson",
+                      value: { type: "Feature", geometry: { type: "Point", coordinates: [0, 0] } },
+                    },
+                    marker: {
+                      imageColor: "#fff",
+                    },
+                  })});`,
+                } as any),
+              },
+            ],
+          },
         },
       },
     },

--- a/web/src/beta/lib/core/Visualizer/index.tsx
+++ b/web/src/beta/lib/core/Visualizer/index.tsx
@@ -1,4 +1,13 @@
-import { CSSProperties, useMemo, type ReactNode } from "react";
+import {
+  CSSProperties,
+  useMemo,
+  type ReactNode,
+  FC,
+  memo,
+  forwardRef,
+  Ref,
+  PropsWithChildren,
+} from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
 import { styled } from "@reearth/services/theme";
@@ -26,7 +35,9 @@ import Map, {
   type Cluster,
   type ComputedLayer,
 } from "../Map";
+import { Ref as MapRef } from "../Map";
 
+import { VisualizerProvider } from "./context";
 import DropHolder from "./DropHolder";
 import { engines, type EngineType } from "./engines";
 import Err from "./Error";
@@ -42,6 +53,8 @@ export type {
 } from "../Crust";
 export type { EngineType } from "./engines";
 export type { Viewport } from "./useViewport";
+
+export { useVisualizer, type Context as VisualizerContext } from "./context";
 
 export type Props = {
   engine?: EngineType;
@@ -105,185 +118,202 @@ export type Props = {
   onBlockDelete?: (id: string) => void;
   onBlockInsert?: (bi: number, i: number, pos?: "top" | "bottom") => void;
   onZoomToLayer?: (layerId: string | undefined) => void;
+  onMount?: () => void;
   renderInfoboxInsertionPopup?: (onSelect: (bi: number) => void, onClose: () => void) => ReactNode;
 } & ExternalPluginProps;
 
-export default function Visualizer({
-  engine,
-  isBuilt,
-  rootLayerId,
-  isEditable,
-  inEditor,
-  sceneProperty,
-  layers,
-  clusters,
-  widgetAlignSystem,
-  widgetAlignSystemEditing,
-  widgetLayoutConstraint,
-  floatingWidgets,
-  ownBuiltinWidgets,
-  small,
-  ready,
-  tags,
-  selectedBlockId,
-  selectedLayerId,
-  selectedWidgetArea,
-  hiddenLayers,
-  camera: initialCamera,
-  interactionMode: initialInteractionMode,
-  meta,
-  style,
-  pluginBaseUrl,
-  pluginProperty,
-  zoomedLayerId,
-  layerSelectionReason,
-  useExperimentalSandbox,
-  onLayerDrop,
-  onLayerSelect,
-  onCameraChange,
-  onWidgetLayoutUpdate,
-  onWidgetAlignmentUpdate,
-  onWidgetAreaSelect,
-  onInfoboxMaskClick,
-  onBlockSelect,
-  onBlockChange,
-  onBlockMove,
-  onBlockDelete,
-  onBlockInsert,
-  onZoomToLayer,
-  renderInfoboxInsertionPopup,
-}: Props): JSX.Element | null {
-  const {
-    mapRef,
-    wrapperRef,
-    selectedLayer,
-    selectedBlock,
-    selectedFeature,
-    selectedComputedFeature,
-    viewport,
-    camera,
-    interactionMode,
-    featureFlags,
-    isMobile,
-    overriddenSceneProperty,
-    overriddenClock,
-    isDroppable,
-    isLayerDragging,
-    infobox,
-    shouldRender,
-    handleLayerSelect,
-    handleBlockSelect,
-    handleCameraChange,
-    handleInteractionModeChange,
-    handleLayerDrag,
-    handleLayerDrop,
-    overrideSceneProperty,
-    handleLayerEdit,
-    onLayerEdit,
-    handleInfoboxClose,
-  } = useHooks({
-    rootLayerId,
-    isEditable,
-    camera: initialCamera,
-    interactionMode: initialInteractionMode,
-    selectedBlockId,
-    sceneProperty,
-    zoomedLayerId,
-    ownBuiltinWidgets,
-    onLayerSelect,
-    onBlockSelect,
-    onCameraChange,
-    onZoomToLayer,
-    onLayerDrop,
-  });
+const Visualizer: FC<PropsWithChildren<Props>> = memo(
+  forwardRef(function VisualizerPresenter(
+    {
+      engine,
+      isBuilt,
+      rootLayerId,
+      isEditable,
+      inEditor,
+      sceneProperty,
+      layers,
+      clusters,
+      widgetAlignSystem,
+      widgetAlignSystemEditing,
+      widgetLayoutConstraint,
+      floatingWidgets,
+      ownBuiltinWidgets,
+      small,
+      ready,
+      tags,
+      selectedBlockId,
+      selectedLayerId,
+      selectedWidgetArea,
+      hiddenLayers,
+      camera: initialCamera,
+      interactionMode: initialInteractionMode,
+      meta,
+      style,
+      pluginBaseUrl,
+      pluginProperty,
+      zoomedLayerId,
+      layerSelectionReason,
+      useExperimentalSandbox,
+      children,
+      onLayerDrop,
+      onLayerSelect,
+      onCameraChange,
+      onWidgetLayoutUpdate,
+      onWidgetAlignmentUpdate,
+      onWidgetAreaSelect,
+      onInfoboxMaskClick,
+      onBlockSelect,
+      onBlockChange,
+      onBlockMove,
+      onBlockDelete,
+      onBlockInsert,
+      onZoomToLayer,
+      onMount,
+      renderInfoboxInsertionPopup,
+    },
+    ref: Ref<MapRef | null>,
+  ) {
+    const {
+      mapRef,
+      wrapperRef,
+      selectedLayer,
+      selectedBlock,
+      selectedFeature,
+      selectedComputedFeature,
+      viewport,
+      camera,
+      interactionMode,
+      featureFlags,
+      isMobile,
+      overriddenSceneProperty,
+      overriddenClock,
+      isDroppable,
+      isLayerDragging,
+      infobox,
+      shouldRender,
+      handleLayerSelect,
+      handleBlockSelect,
+      handleCameraChange,
+      handleInteractionModeChange,
+      handleLayerDrag,
+      handleLayerDrop,
+      overrideSceneProperty,
+      handleLayerEdit,
+      onLayerEdit,
+      handleInfoboxClose,
+    } = useHooks(
+      {
+        rootLayerId,
+        isEditable,
+        camera: initialCamera,
+        interactionMode: initialInteractionMode,
+        selectedBlockId,
+        sceneProperty,
+        zoomedLayerId,
+        ownBuiltinWidgets,
+        onLayerSelect,
+        onBlockSelect,
+        onCameraChange,
+        onZoomToLayer,
+        onLayerDrop,
+      },
+      ref,
+    );
 
-  const selectedLayerIdForCrust = useMemo(
-    () => ({ layerId: selectedLayer.layerId, featureId: selectedLayer.featureId }),
-    [selectedLayer.featureId, selectedLayer.layerId],
-  );
+    const selectedLayerIdForCrust = useMemo(
+      () => ({ layerId: selectedLayer.layerId, featureId: selectedLayer.featureId }),
+      [selectedLayer.featureId, selectedLayer.layerId],
+    );
 
-  return (
-    <ErrorBoundary FallbackComponent={Err}>
-      <Filled ref={wrapperRef}>
-        {isDroppable && <DropHolder />}
-        <Crust
-          engineName={engine}
-          tags={tags}
-          viewport={viewport}
-          isBuilt={isBuilt}
-          isEditable={isEditable && infobox?.isEditable}
-          inEditor={inEditor}
-          sceneProperty={overriddenSceneProperty}
-          overrideSceneProperty={overrideSceneProperty}
-          overriddenClock={overriddenClock}
-          blocks={infobox?.blocks}
-          camera={camera}
-          interactionMode={interactionMode}
-          overrideInteractionMode={handleInteractionModeChange}
-          isMobile={isMobile}
-          selectedWidgetArea={selectedWidgetArea}
-          selectedComputedLayer={selectedLayer?.layer}
-          selectedFeature={selectedFeature}
-          selectedComputedFeature={selectedComputedFeature}
-          selectedReason={selectedLayer.reason}
-          infoboxProperty={infobox?.property}
-          infoboxTitle={infobox?.title}
-          infoboxVisible={!!infobox?.visible}
-          selectedBlockId={selectedBlock}
-          selectedLayerId={selectedLayerIdForCrust}
-          widgetAlignSystem={widgetAlignSystem}
-          widgetAlignSystemEditing={widgetAlignSystemEditing}
-          widgetLayoutConstraint={widgetLayoutConstraint}
-          floatingWidgets={floatingWidgets}
-          mapRef={mapRef}
-          externalPlugin={{ pluginBaseUrl, pluginProperty }}
-          useExperimentalSandbox={useExperimentalSandbox}
-          onWidgetLayoutUpdate={onWidgetLayoutUpdate}
-          onWidgetAlignmentUpdate={onWidgetAlignmentUpdate}
-          onWidgetAreaSelect={onWidgetAreaSelect}
-          onInfoboxMaskClick={onInfoboxMaskClick}
-          onInfoboxClose={handleInfoboxClose}
-          onBlockSelect={handleBlockSelect}
-          onBlockChange={onBlockChange}
-          onBlockMove={onBlockMove}
-          onBlockDelete={onBlockDelete}
-          onBlockInsert={onBlockInsert}
-          renderInfoboxInsertionPopup={renderInfoboxInsertionPopup}
-          onLayerEdit={onLayerEdit}
-        />
-        <Map
-          ref={mapRef}
-          isBuilt={isBuilt}
-          isEditable={isEditable}
-          engine={engine}
-          layers={layers}
-          engines={engines}
-          camera={camera}
-          overriddenClock={overriddenClock}
-          clusters={clusters}
-          hiddenLayers={hiddenLayers}
-          isLayerDragging={isLayerDragging}
-          isLayerDraggable={isEditable}
-          meta={meta}
-          style={style}
-          featureFlags={featureFlags}
-          shouldRender={shouldRender}
-          // overrides={overrides} // not used for now
-          property={overriddenSceneProperty}
-          selectedLayerId={selectedLayerId}
-          layerSelectionReason={layerSelectionReason}
-          small={small}
-          ready={ready}
-          onCameraChange={handleCameraChange}
-          onLayerDrag={handleLayerDrag}
-          onLayerDrop={handleLayerDrop}
-          onLayerSelect={handleLayerSelect}
-          onLayerEdit={handleLayerEdit}
-        />
-      </Filled>
-    </ErrorBoundary>
-  );
-}
+    return (
+      <ErrorBoundary FallbackComponent={Err}>
+        <VisualizerProvider mapRef={mapRef}>
+          <Filled ref={wrapperRef}>
+            {isDroppable && <DropHolder />}
+            <Crust
+              engineName={engine}
+              tags={tags}
+              viewport={viewport}
+              isBuilt={isBuilt}
+              isEditable={isEditable && infobox?.isEditable}
+              inEditor={inEditor}
+              sceneProperty={overriddenSceneProperty}
+              overrideSceneProperty={overrideSceneProperty}
+              overriddenClock={overriddenClock}
+              blocks={infobox?.blocks}
+              camera={camera}
+              interactionMode={interactionMode}
+              overrideInteractionMode={handleInteractionModeChange}
+              isMobile={isMobile}
+              selectedWidgetArea={selectedWidgetArea}
+              selectedComputedLayer={selectedLayer?.layer}
+              selectedFeature={selectedFeature}
+              selectedComputedFeature={selectedComputedFeature}
+              selectedReason={selectedLayer.reason}
+              infoboxProperty={infobox?.property}
+              infoboxTitle={infobox?.title}
+              infoboxVisible={!!infobox?.visible}
+              selectedBlockId={selectedBlock}
+              selectedLayerId={selectedLayerIdForCrust}
+              widgetAlignSystem={widgetAlignSystem}
+              widgetAlignSystemEditing={widgetAlignSystemEditing}
+              widgetLayoutConstraint={widgetLayoutConstraint}
+              floatingWidgets={floatingWidgets}
+              mapRef={mapRef}
+              externalPlugin={{ pluginBaseUrl, pluginProperty }}
+              useExperimentalSandbox={useExperimentalSandbox}
+              onWidgetLayoutUpdate={onWidgetLayoutUpdate}
+              onWidgetAlignmentUpdate={onWidgetAlignmentUpdate}
+              onWidgetAreaSelect={onWidgetAreaSelect}
+              onInfoboxMaskClick={onInfoboxMaskClick}
+              onInfoboxClose={handleInfoboxClose}
+              onBlockSelect={handleBlockSelect}
+              onBlockChange={onBlockChange}
+              onBlockMove={onBlockMove}
+              onBlockDelete={onBlockDelete}
+              onBlockInsert={onBlockInsert}
+              renderInfoboxInsertionPopup={renderInfoboxInsertionPopup}
+              onLayerEdit={onLayerEdit}
+            />
+            <Map
+              ref={mapRef}
+              isBuilt={isBuilt}
+              isEditable={isEditable}
+              engine={engine}
+              layers={layers}
+              engines={engines}
+              camera={camera}
+              overriddenClock={overriddenClock}
+              clusters={clusters}
+              hiddenLayers={hiddenLayers}
+              isLayerDragging={isLayerDragging}
+              isLayerDraggable={isEditable}
+              meta={meta}
+              style={style}
+              featureFlags={featureFlags}
+              shouldRender={shouldRender}
+              // overrides={overrides} // not used for now
+              property={overriddenSceneProperty}
+              selectedLayerId={selectedLayerId}
+              layerSelectionReason={layerSelectionReason}
+              small={small}
+              ready={ready}
+              onCameraChange={handleCameraChange}
+              onLayerDrag={handleLayerDrag}
+              onLayerDrop={handleLayerDrop}
+              onLayerSelect={handleLayerSelect}
+              onLayerEdit={handleLayerEdit}
+              onMount={onMount}
+            />
+          </Filled>
+          {children}
+        </VisualizerProvider>
+      </ErrorBoundary>
+    );
+  }),
+);
+
+export default Visualizer;
 
 const Filled = styled.div`
   width: 100%;

--- a/web/src/beta/lib/core/engines/Cesium/hooks.ts
+++ b/web/src/beta/lib/core/engines/Cesium/hooks.ts
@@ -58,6 +58,7 @@ export default ({
   onLayerDrag,
   onLayerDrop,
   onLayerEdit,
+  onMount,
 }: {
   ref: React.ForwardedRef<EngineRef>;
   property?: SceneProperty;
@@ -85,6 +86,7 @@ export default ({
     position: LatLng | undefined,
   ) => void;
   onLayerEdit?: (e: LayerEditEvent) => void;
+  onMount?: () => void;
 }) => {
   const cesium = useRef<CesiumComponentRef<CesiumViewer>>(null);
   const cesiumIonDefaultAccessToken =
@@ -238,18 +240,21 @@ export default ({
       if (camera) {
         onCameraChange?.(camera);
       }
+      onMount?.();
     },
     [
       engineAPI,
       onCameraChange,
       property?.default?.camera,
       property?.cameraLimiter?.cameraLimitterEnabled,
+      onMount,
     ],
     (prevDeps, nextDeps) =>
       prevDeps[0] === nextDeps[0] &&
       prevDeps[1] === nextDeps[1] &&
       isEqual(prevDeps[2], nextDeps[2]) &&
-      prevDeps[3] === nextDeps[3],
+      prevDeps[3] === nextDeps[3] &&
+      prevDeps[4] === nextDeps[4],
   );
 
   const handleUnmount = useCallback(() => {

--- a/web/src/beta/lib/core/engines/Cesium/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/index.tsx
@@ -51,6 +51,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     onLayerDrag,
     onLayerDrop,
     onLayerEdit,
+    onMount,
   },
   ref,
 ) => {
@@ -86,6 +87,7 @@ const Cesium: React.ForwardRefRenderFunction<EngineRef, EngineProps> = (
     onLayerDrag,
     onLayerDrop,
     onLayerEdit,
+    onMount,
   });
 
   return (


### PR DESCRIPTION
# Overview

I added VisualizerContext API to access to the API of the Visualizer.

You can access like this.

```tsx
const visualizer = useVisualizer();
visualizer.current?.engine.flyTo({
  lat: 35.683252649879606,
  lng: 139.75262379931652,
  height: 5000,
});
visualizer.current?.layers.add({
  type: "simple",
  data: {
    type: "geojson",
    value: {
      // GeoJSON
      type: "Feature",
      geometry: {
        coordinates: [139.75262379931652, 35.683252649879606, 1000],
        type: "Point",
      },
    },
  },
  marker: {
    imageColor: "blue",
  },
});
```

## What I've done

- Added VisualizerContext API
- Added onMount props to Visualizer

## What I haven't done

## How I tested

1. Go to storybook on preview
2. Move to `?path/story/beta-lib-core-visualizer--api`
3. Set the Cesium token to `meta` props on the bottom bar in storybook
```
{
"cesiumIonAccessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJhYzVkMTc1ZS00NTRhLTRjY2QtYTQwZS01YmU2Mjg1ODAwN2YiLCJpZCI6MjU5LCJpYXQiOjE2ODgzOTgwMjl9.MZC_HUBRd0y5HJeB-F5QSpT-fEgTM6mI5gMaSND9FHc"
}
```
5. Reload the page, then camera is moved and one marker is added.

## Which point I want you to review particularly

## Memo
