### PR TITLE
fix(web): suppress error in loading built-in plugin

### DIFF
--- a/web/src/services/config/unsafeBuiltinPlugin.ts
+++ b/web/src/services/config/unsafeBuiltinPlugin.ts
@@ -42,5 +42,5 @@ export const loadUnsafeBuiltinPlugins = async (urls: string[]) => {
           return;
       }
     })
-    .filter(Boolean);
+    .filter((v): v is UnsafeBuiltinPlugin => !!v);
 };

--- a/web/src/services/config/unsafeBuiltinPlugin.ts
+++ b/web/src/services/config/unsafeBuiltinPlugin.ts
@@ -21,16 +21,21 @@ type UnsafeBuiltinPluginExtension<T extends "widget" | "block"> = {
 export type UnsafeBuiltinWidgets<T = unknown> = Record<string, T>;
 
 export const loadUnsafeBuiltinPlugins = async (urls: string[]) => {
-  return (
-    await Promise.all(
-      urls.map(async url => {
-        try {
-          const plugin: UnsafeBuiltinPlugin = (await import(/* @vite-ignore */ url)).default;
-          return plugin;
-        } catch (e) {
-          throw new Error(`Specified unsafe built-in module could not find: ${url} ${e}`);
-        }
-      }),
-    )
-  ).filter(Boolean);
+  try {
+    return (
+      await Promise.all(
+        urls.map(async url => {
+          try {
+            const plugin: UnsafeBuiltinPlugin = (await import(/* @vite-ignore */ url)).default;
+            return plugin;
+          } catch (e) {
+            throw new Error(`Specified unsafe built-in module could not find: ${url} ${e}`);
+          }
+        }),
+      )
+    ).filter(Boolean);
+  } catch (e) {
+    console.warn(e);
+    return;
+  }
 };

--- a/web/src/services/config/unsafeBuiltinPlugin.ts
+++ b/web/src/services/config/unsafeBuiltinPlugin.ts
@@ -21,21 +21,26 @@ type UnsafeBuiltinPluginExtension<T extends "widget" | "block"> = {
 export type UnsafeBuiltinWidgets<T = unknown> = Record<string, T>;
 
 export const loadUnsafeBuiltinPlugins = async (urls: string[]) => {
-  try {
-    return (
-      await Promise.all(
-        urls.map(async url => {
-          try {
-            const plugin: UnsafeBuiltinPlugin = (await import(/* @vite-ignore */ url)).default;
-            return plugin;
-          } catch (e) {
-            throw new Error(`Specified unsafe built-in module could not find: ${url} ${e}`);
-          }
-        }),
-      )
-    ).filter(Boolean);
-  } catch (e) {
-    console.warn(e);
-    return;
-  }
+  return (
+    await Promise.allSettled(
+      urls.map(async url => {
+        try {
+          const plugin: UnsafeBuiltinPlugin = (await import(/* @vite-ignore */ url)).default;
+          return plugin;
+        } catch (e) {
+          throw new Error(`Specified unsafe built-in module could not find: ${url} ${e}`);
+        }
+      }),
+    )
+  )
+    .map(val => {
+      switch (val.status) {
+        case "fulfilled":
+          return val.value;
+        case "rejected":
+          console.warn(val.reason);
+          return;
+      }
+    })
+    .filter(Boolean);
 };


### PR DESCRIPTION
# Overview
Re:Earth is logged out when built-in plugin load is failed. So I fixed to suppress the error.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
