### PR TITLE
feat(server): add env var to specify account database

### DIFF
--- a/server/internal/app/config/config.go
+++ b/server/internal/app/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	Host_Web         string
 	Dev              bool
 	DB               string `default:"mongodb://localhost"`
+	DB_Account       string
 	GraphQL          GraphQLConfig
 	Published        PublishedConfig
 	GCPProject       string `envconfig:"GOOGLE_CLOUD_PROJECT"`

--- a/server/internal/infrastructure/mongo/container.go
+++ b/server/internal/infrastructure/mongo/container.go
@@ -14,6 +14,7 @@ import (
 	"github.com/reearth/reearth/server/pkg/scene"
 	"github.com/reearth/reearthx/account/accountdomain/user"
 	"github.com/reearth/reearthx/account/accountinfrastructure/accountmongo"
+	"github.com/reearth/reearthx/account/accountusecase/accountrepo"
 	"github.com/reearth/reearthx/authserver"
 	"github.com/reearth/reearthx/log"
 	"github.com/reearth/reearthx/mongox"
@@ -23,7 +24,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-func New(ctx context.Context, db *mongo.Database, useTransaction bool) (*repo.Container, error) {
+func New(ctx context.Context, db *mongo.Database, account *accountrepo.Container, useTransaction bool) (*repo.Container, error) {
 	lock, err := NewLock(db.Collection("locks"))
 	if err != nil {
 		return nil, err
@@ -47,13 +48,13 @@ func New(ctx context.Context, db *mongo.Database, useTransaction bool) (*repo.Co
 		Property:       NewProperty(client),
 		Scene:          NewScene(client),
 		Tag:            NewTag(client),
-		Workspace:      accountmongo.NewWorkspaceCompat(client),
-		User:           accountmongo.NewUser(client),
 		SceneLock:      NewSceneLock(client),
 		Policy:         NewPolicy(client),
 		Storytelling:   NewStorytelling(client),
 		Lock:           lock,
 		Transaction:    client.Transaction(),
+		Workspace:      account.Workspace,
+		User:           account.User,
 	}
 
 	// init
@@ -69,8 +70,8 @@ func New(ctx context.Context, db *mongo.Database, useTransaction bool) (*repo.Co
 	return c, nil
 }
 
-func NewWithExtensions(ctx context.Context, db *mongo.Database, useTransaction bool, src []string) (*repo.Container, error) {
-	c, err := New(ctx, db, useTransaction)
+func NewWithExtensions(ctx context.Context, db *mongo.Database, account *accountrepo.Container, useTransaction bool, src []string) (*repo.Container, error) {
+	c, err := New(ctx, db, account, useTransaction)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/usecase/interactor/dataset.go
+++ b/server/internal/usecase/interactor/dataset.go
@@ -32,13 +32,13 @@ type Dataset struct {
 	common
 	commonSceneLock
 	sceneRepo         repo.Scene
-	workspaceRepo     accountrepo.Workspace
 	datasetRepo       repo.Dataset
 	datasetSchemaRepo repo.DatasetSchema
 	propertyRepo      repo.Property
 	layerRepo         repo.Layer
 	pluginRepo        repo.Plugin
-	policyRepo        repo.Policy
+	workspaceRepo     accountrepo.Workspace
+	policyRepo        accountrepo.Policy
 	datasource        gateway.DataSource
 	file              gateway.File
 	google            gateway.Google

--- a/server/internal/usecase/interactor/layer.go
+++ b/server/internal/usecase/interactor/layer.go
@@ -42,7 +42,7 @@ type Layer struct {
 	datasetSchemaRepo  repo.DatasetSchema
 	sceneRepo          repo.Scene
 	sceneLockRepo      repo.SceneLock
-	policyRepo         repo.Policy
+	policyRepo         accountrepo.Policy
 	workspaceRepo      accountrepo.Workspace
 	transaction        usecasex.Transaction
 }

--- a/server/internal/usecase/repo/container.go
+++ b/server/internal/usecase/repo/container.go
@@ -39,6 +39,15 @@ type Container struct {
 	Extensions     []plugin.ID
 }
 
+func (c *Container) AccountRepos() *accountrepo.Container {
+	return &accountrepo.Container{
+		Workspace: c.Workspace,
+		User:      c.User,
+		// TODO: Policy: c.Policy,
+		Transaction: c.Transaction,
+	}
+}
+
 func (c *Container) Filtered(workspace WorkspaceFilter, scene SceneFilter) *Container {
 	if c == nil {
 		return c


### PR DESCRIPTION
# Overview

## What I've done

Add an env var (REEARTH_DB_ACCOUNT) to specify the database name for accounts, separate from the regular database

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
