### PR TITLE
chore(web): fix the layer delete behavior

### DIFF
--- a/web/src/beta/lib/core/Map/Layers/hooks.ts
+++ b/web/src/beta/lib/core/Map/Layers/hooks.ts
@@ -545,6 +545,7 @@ export default function useHooks({
     ],
   );
 
+  const prevLayers = useRef<Layer[] | undefined>([]);
   useLayoutEffect(() => {
     const ids = new Set<string>();
 
@@ -556,14 +557,16 @@ export default function useHooks({
       layerMap.set(l.id, l);
     });
 
-    const deleted = Array.from(atomMap.keys()).filter(k => !ids.has(k));
-    deleted.forEach(k => {
+    const deleted = prevLayers.current?.filter(l => !ids.has(l.id)).map(l => l.id);
+    deleted?.forEach(k => {
       atomMap.delete(k);
       layerMap.delete(k);
       lazyLayerMap.delete(k);
       showLayer(k);
     });
-    setOverridenLayers(layers => layers.filter(l => !deleted.includes(l.id)));
+    setOverridenLayers(layers => layers.filter(l => !deleted?.includes(l.id)));
+
+    prevLayers.current = layers;
   }, [atomMap, layers, layerMap, lazyLayerMap, setOverridenLayers, showLayer]);
 
   useEffect(() => {


### PR DESCRIPTION
# Overview

I noticed this script doesn't work due to layers are deleted unexpectedly when Visualizer's `layer` prop is updated. 

```
const id = reearth.layers.add({
  type: "simple",
  data: {
      type: "3dtiles",
      url: "https://assets.cms.plateau.reearth.io/assets/ca/ee4cb0-9ce4-4f6c-bca1-9c7623e84cb1/13100_tokyo23-ku_2022_3dtiles_1_1_op_bldg_13101_chiyoda-ku_lod2_no_texture/tileset.json"
  },
  "3dtiles": {},
})
setTimeout(() => {
  reearth.camera.flyTo(id);
}, 100);
```

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
