### PR TITLE
chore(web): fix HBAO error when Cesium is destroyed

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/useOverrideGlobeShader.ts
+++ b/web/src/beta/lib/core/engines/Cesium/useOverrideGlobeShader.ts
@@ -127,8 +127,10 @@ export const useOverrideGlobeShader = ({
       defines: baseFragmentShaderSource.defines,
     });
     return () => {
-      // Reset customized shader to default
-      makeGlobeShadersDirty(globe);
+      if (!globe.isDestroyed()) {
+        // Reset customized shader to default
+        makeGlobeShadersDirty(globe);
+      }
     };
   }, [
     sphericalHarmonicCoefficientsRefFunc,


### PR DESCRIPTION
# Overview

In VIEW3.0, application is crashed when back to the dashboard while HBAO is enabled. So I fixed this error.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
