### PR TITLE
chore(web): refactor plugin API camera.getFovInfo

### DIFF
--- a/web/src/beta/lib/core/Crust/Plugins/api.ts
+++ b/web/src/beta/lib/core/Crust/Plugins/api.ts
@@ -328,7 +328,7 @@ export function commonReearth({
   zoomIn,
   zoomOut,
   cameraViewport,
-  getCameraFovCenter,
+  getCameraFovInfo,
   orbit,
   rotateRight,
   captureScreen,
@@ -375,7 +375,7 @@ export function commonReearth({
   rotateRight: GlobalThis["reearth"]["camera"]["rotateRight"];
   orbit: GlobalThis["reearth"]["camera"]["orbit"];
   cameraViewport?: () => GlobalThis["reearth"]["camera"]["viewport"];
-  getCameraFovCenter: GlobalThis["reearth"]["camera"]["getFovCenter"];
+  getCameraFovInfo: GlobalThis["reearth"]["camera"]["getFovInfo"];
   captureScreen: GlobalThis["reearth"]["scene"]["captureScreen"];
   getLocationFromScreen: GlobalThis["reearth"]["scene"]["getLocationFromScreen"];
   sampleTerrainHeight: GlobalThis["reearth"]["scene"]["sampleTerrainHeight"];
@@ -413,7 +413,7 @@ export function commonReearth({
         get viewport() {
           return cameraViewport?.();
         },
-        getFovCenter: getCameraFovCenter,
+        getFovInfo: getCameraFovInfo,
         enableScreenSpaceController: enableScreenSpaceCameraController,
         lookHorizontal,
         lookVertical,
@@ -469,7 +469,7 @@ export function commonReearth({
       get viewport() {
         return cameraViewport?.();
       },
-      getFovCenter: getCameraFovCenter,
+      getFovInfo: getCameraFovInfo,
       enableScreenSpaceController: enableScreenSpaceCameraController,
       lookHorizontal,
       lookVertical,

--- a/web/src/beta/lib/core/Crust/Plugins/hooks.ts
+++ b/web/src/beta/lib/core/Crust/Plugins/hooks.ts
@@ -112,9 +112,9 @@ export default function ({
     return engineRef?.getViewport();
   }, [engineRef]);
 
-  const getCameraFovCenter = useCallback(
+  const getCameraFovInfo = useCallback(
     (withTerrain?: boolean) => {
-      return engineRef?.getCameraFovCenter(withTerrain);
+      return engineRef?.getCameraFovInfo(withTerrain);
     },
     [engineRef],
   );
@@ -330,7 +330,7 @@ export default function ({
         zoomIn,
         zoomOut,
         cameraViewport,
-        getCameraFovCenter,
+        getCameraFovInfo,
         rotateRight,
         orbit,
         captureScreen,
@@ -383,7 +383,7 @@ export default function ({
       zoomIn,
       zoomOut,
       cameraViewport,
-      getCameraFovCenter,
+      getCameraFovInfo,
       rotateRight,
       orbit,
       captureScreen,

--- a/web/src/beta/lib/core/Crust/Plugins/plugin_types.ts
+++ b/web/src/beta/lib/core/Crust/Plugins/plugin_types.ts
@@ -134,7 +134,12 @@ export type Camera = {
   /** Current camera position */
   readonly position: CameraPosition | undefined;
   readonly viewport: Rect | undefined;
-  readonly getFovCenter: (withTerrain?: boolean) => LatLngHeight | undefined;
+  readonly getFovInfo: (withTerrain?: boolean) =>
+    | {
+        center?: LatLngHeight;
+        viewSize?: number;
+      }
+    | undefined;
   readonly zoomIn: (amount: number, options?: CameraOptions) => void;
   readonly zoomOut: (amount: number, options?: CameraOptions) => void;
   /** Moves the camera position to the specified destination. */

--- a/web/src/beta/lib/core/Crust/Plugins/storybook.tsx
+++ b/web/src/beta/lib/core/Crust/Plugins/storybook.tsx
@@ -124,7 +124,7 @@ export const context: Context = {
         fov: Math.PI * (60 / 180),
       },
       viewport: { west: 0, east: 0, north: 0, south: 0 },
-      getFovCenter: act("getFovCenter"),
+      getFovInfo: act("getFovInfo"),
       enableScreenSpaceController: act("enableScreenSpaceController"),
       flyTo: act("flyTo"),
       lookAt: act("lookAt"),

--- a/web/src/beta/lib/core/Map/ref.ts
+++ b/web/src/beta/lib/core/Map/ref.ts
@@ -17,7 +17,7 @@ const engineRefKeys: FunctionKeys<EngineRef> = {
   flyTo: 1,
   flyToGround: 1,
   getCamera: 1,
-  getCameraFovCenter: 1,
+  getCameraFovInfo: 1,
   getClock: 1,
   getLocationFromScreen: 1,
   sampleTerrainHeight: 1,

--- a/web/src/beta/lib/core/Map/types/index.ts
+++ b/web/src/beta/lib/core/Map/types/index.ts
@@ -61,7 +61,12 @@ export type EngineRef = {
   requestRender: () => void;
   getViewport: () => Rect | undefined;
   getCamera: () => Camera | undefined;
-  getCameraFovCenter: (withTerrain?: boolean) => LatLngHeight | undefined;
+  getCameraFovInfo: (withTerrain?: boolean) =>
+    | {
+        center?: LatLngHeight;
+        viewSize?: number;
+      }
+    | undefined;
   getLocationFromScreen: (x: number, y: number, withTerrain?: boolean) => LatLngHeight | undefined;
   sampleTerrainHeight: (lng: number, lat: number) => Promise<number | undefined>;
   flyTo: (target: string | FlyToDestination, options?: CameraOptions) => void;

--- a/web/src/beta/lib/core/engines/Cesium/common.ts
+++ b/web/src/beta/lib/core/engines/Cesium/common.ts
@@ -38,6 +38,7 @@ import { useCallback, MutableRefObject } from "react";
 import { ClassificationType } from "@reearth/beta/lib/core/mantle";
 import { useCanvas, useImage } from "@reearth/beta/utils/image";
 import { tweenInterval } from "@reearth/beta/utils/raf";
+import { LatLngHeight } from "@reearth/beta/utils/value";
 
 import type { Camera, CameraOptions, Clock, FlyToDestination } from "..";
 
@@ -227,7 +228,7 @@ export const getCameraTerrainIntersection = (scene: Scene): any => {
   return scene.globe.pick(ray, scene);
 };
 
-export const cartesianToLatLngHeight = (cartesian: Cartesian3, scene: Scene): any => {
+export const cartesianToLatLngHeight = (cartesian: Cartesian3, scene: Scene): LatLngHeight => {
   const cartographic = Cartographic.fromCartesian(cartesian, scene.globe.ellipsoid);
   return {
     lng: CesiumMath.toDegrees(cartographic.longitude),


### PR DESCRIPTION
# Overview

In this PR i replaced plugin API `camera.getFovCenter` with `camera.getFovInfo` to provide the viewSize as well.

```ts
getFovInfo: (withTerrain?: boolean) =>
    | {
        center?: LatLngHeight;
        viewSize?: number;
      }
    | undefined;
```

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
