### PR TITLE
fix(web): remove video URL format verification

### DIFF
--- a/web/src/beta/components/fields/URLField/index.tsx
+++ b/web/src/beta/components/fields/URLField/index.tsx
@@ -4,11 +4,7 @@ import Button from "@reearth/beta/components/Button";
 import Property from "@reearth/beta/components/fields";
 import TextInput from "@reearth/beta/components/fields/common/TextInput";
 import useHooks from "@reearth/beta/features/Assets/AssetsQueriesHook/hooks";
-import {
-  FILE_FORMATS,
-  IMAGE_FORMATS,
-  VIDEO_FORMATS,
-} from "@reearth/beta/features/Assets/constants";
+import { FILE_FORMATS, IMAGE_FORMATS } from "@reearth/beta/features/Assets/constants";
 import { Asset } from "@reearth/beta/features/Assets/types";
 import { useManageAssets } from "@reearth/beta/features/Assets/useManageAssets/hooks";
 import ChooseAssetModal from "@reearth/beta/features/Modals/ChooseAssetModal";
@@ -44,13 +40,6 @@ const URLField: React.FC<Props> = ({ name, description, value, fileType, assetTy
         setNotification({
           type: "error",
           text: t("Wrong file format"),
-        });
-        setCurrentValue(undefined);
-        return;
-      } else if (fileType === "URL" && !checkIfFileType(inputValue, VIDEO_FORMATS)) {
-        setNotification({
-          type: "error",
-          text: t("wrong Video URL Format"),
         });
         setCurrentValue(undefined);
         return;

--- a/web/src/beta/features/Assets/constants.ts
+++ b/web/src/beta/features/Assets/constants.ts
@@ -1,5 +1,3 @@
 export const FILE_FORMATS = ".kml,.czml,.topojson,.geojson,.json,.gltf,.glb";
 
 export const IMAGE_FORMATS = ".jpg,.jpeg,.png,.gif,.svg,.tiff,.webp";
-
-export const VIDEO_FORMATS = ".mp4";

--- a/web/src/services/i18n/translations/en.yml
+++ b/web/src/services/i18n/translations/en.yml
@@ -527,5 +527,3 @@ Size Large to Small: Size Large to Small
 Please select an asset before clicking Select.: Please select an asset before clicking Select.
 Select Image: Select Image
 Wrong file format: Wrong file format
-wrong Video URL Format: wrong Video URL Format
-

--- a/web/src/services/i18n/translations/ja.yml
+++ b/web/src/services/i18n/translations/ja.yml
@@ -488,4 +488,3 @@ Size Large to Small: Size Large to Small
 Please select an asset before clicking Select.: Please select an asset before clicking Select.
 Select Image: イメージ選択
 Wrong file format: Wrong file format
-wrong Video URL Format: wrong Video URL Format


### PR DESCRIPTION
# Overview
This PR is to remove the video format verification as not all video URL should have same video format.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
