### PR TITLE
fix(server): workspace member count is not limited by policies

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/paulmach/go.geojson v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/ravilushqa/otelgqlgen v0.8.0
-	github.com/reearth/reearthx v0.0.0-20231004095401-bceec5158e2a
+	github.com/reearth/reearthx v0.0.0-20231004111936-81f4cb96b88f
 	github.com/samber/lo v1.27.0
 	github.com/spf13/afero v1.9.3
 	github.com/square/mongo-lock v0.0.0-20201208161834-4db518ed7fb2

--- a/server/go.sum
+++ b/server/go.sum
@@ -501,6 +501,10 @@ github.com/reearth/reearthx v0.0.0-20231004090951-7e7cbfdb49ba h1:O+R6Pjm5gwPSje
 github.com/reearth/reearthx v0.0.0-20231004090951-7e7cbfdb49ba/go.mod h1:b8EygPZ9VcMv9vTbnl/oz3PU/wHz3wpBa4rc7W7URjw=
 github.com/reearth/reearthx v0.0.0-20231004095401-bceec5158e2a h1:/aUjXiRKu+YlbhOmiNnCKgtjJqvomQsMg2PNDX655Wc=
 github.com/reearth/reearthx v0.0.0-20231004095401-bceec5158e2a/go.mod h1:b8EygPZ9VcMv9vTbnl/oz3PU/wHz3wpBa4rc7W7URjw=
+github.com/reearth/reearthx v0.0.0-20231004110218-b02e3f864b80 h1:a+bsD5ASDbNUDhNPN+IEPKl8fBmwtPqhkOlb3mWUsdg=
+github.com/reearth/reearthx v0.0.0-20231004110218-b02e3f864b80/go.mod h1:b8EygPZ9VcMv9vTbnl/oz3PU/wHz3wpBa4rc7W7URjw=
+github.com/reearth/reearthx v0.0.0-20231004111936-81f4cb96b88f h1:k2PShuS6Rfj7i5HlHXht5vNghi4/s0osSsQs4Dj2mco=
+github.com/reearth/reearthx v0.0.0-20231004111936-81f4cb96b88f/go.mod h1:b8EygPZ9VcMv9vTbnl/oz3PU/wHz3wpBa4rc7W7URjw=
 github.com/robertkrimen/godocdown v0.0.0-20130622164427-0bfa04905481/go.mod h1:C9WhFzY47SzYBIvzFqSvHIR6ROgDo4TtdTuRaOMjF/s=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/server/internal/app/auth_client.go
+++ b/server/internal/app/auth_client.go
@@ -116,6 +116,7 @@ func generateOperator(ctx context.Context, cfg *ServerConfig, u *user.User) (*us
 	readableWorkspaces := workspaces.FilterByUserRole(uid, workspace.RoleReader).IDs()
 	writableWorkspaces := workspaces.FilterByUserRole(uid, workspace.RoleWriter).IDs()
 	owningWorkspaces := workspaces.FilterByUserRole(uid, workspace.RoleOwner).IDs()
+	defaultPolicy := util.CloneRef(cfg.Config.Policy.Default)
 
 	return &usecase.Operator{
 		AcOperator: &accountusecase.Operator{
@@ -123,12 +124,12 @@ func generateOperator(ctx context.Context, cfg *ServerConfig, u *user.User) (*us
 			ReadableWorkspaces: readableWorkspaces,
 			WritableWorkspaces: writableWorkspaces,
 			OwningWorkspaces:   owningWorkspaces,
+			DefaultPolicy:      defaultPolicy,
 		},
-
 		ReadableScenes: scenes.FilterByWorkspace(readableWorkspaces...).IDs(),
 		WritableScenes: scenes.FilterByWorkspace(writableWorkspaces...).IDs(),
 		OwningScenes:   scenes.FilterByWorkspace(owningWorkspaces...).IDs(),
-		DefaultPolicy:  util.CloneRef(cfg.Config.Policy.Default),
+		DefaultPolicy:  defaultPolicy,
 	}, nil
 }
 

--- a/server/internal/usecase/interactor/common.go
+++ b/server/internal/usecase/interactor/common.go
@@ -49,7 +49,7 @@ func NewContainer(r *repo.Container, g *gateway.Container,
 		Scene:        NewScene(r, g),
 		Tag:          NewTag(r),
 		StoryTelling: NewStorytelling(r, g),
-		Workspace:    accountinteractor.NewWorkspace(ar),
+		Workspace:    accountinteractor.NewWorkspace(ar, workspaceMemberCountEnforcer(r)),
 		User:         accountinteractor.NewUser(ar, ag, config.SignupSecret, config.AuthSrvUIDomain),
 	}
 }

--- a/server/internal/usecase/interactor/policy.go
+++ b/server/internal/usecase/interactor/policy.go
@@ -2,9 +2,15 @@ package interactor
 
 import (
 	"context"
+	"errors"
 
 	"github.com/reearth/reearth/server/internal/usecase/repo"
 	"github.com/reearth/reearth/server/pkg/policy"
+	"github.com/reearth/reearthx/account/accountdomain/user"
+	"github.com/reearth/reearthx/account/accountdomain/workspace"
+	"github.com/reearth/reearthx/account/accountusecase"
+	"github.com/reearth/reearthx/account/accountusecase/accountinteractor"
+	"github.com/reearth/reearthx/rerror"
 )
 
 type Policy struct {
@@ -18,4 +24,24 @@ func NewPolicy(repos *repo.Container) *Policy {
 func (i *Policy) FetchPolicy(ctx context.Context, ids []policy.ID) ([]*policy.Policy, error) {
 	res, err := i.repos.Policy.FindByIDs(ctx, ids)
 	return res, err
+}
+
+func workspaceMemberCountEnforcer(r *repo.Container) accountinteractor.WorkspaceMemberCountEnforcer {
+	return func(ctx context.Context, ws *workspace.Workspace, _ user.List, op *accountusecase.Operator) error {
+		policyID := op.Policy(ws.Policy())
+		if policyID == nil || *policyID == "" {
+			return nil
+		}
+
+		policy, err := r.Policy.FindByID(ctx, *policyID)
+		if err != nil && !errors.Is(err, rerror.ErrNotFound) {
+			return err
+		}
+
+		if policy == nil {
+			return nil
+		}
+
+		return policy.EnforceMemberCount(ws.Members().Count() + 1)
+	}
 }

--- a/server/internal/usecase/interactor/policy.go
+++ b/server/internal/usecase/interactor/policy.go
@@ -10,7 +10,6 @@ import (
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
 	"github.com/reearth/reearthx/account/accountusecase"
 	"github.com/reearth/reearthx/account/accountusecase/accountinteractor"
-	"github.com/reearth/reearthx/rerror"
 )
 
 type Policy struct {
@@ -34,12 +33,12 @@ func workspaceMemberCountEnforcer(r *repo.Container) accountinteractor.Workspace
 		}
 
 		policy, err := r.Policy.FindByID(ctx, *policyID)
-		if err != nil && !errors.Is(err, rerror.ErrNotFound) {
+		if err != nil {
 			return err
 		}
 
 		if policy == nil {
-			return nil
+			return errors.New("invalid policy")
 		}
 
 		return policy.EnforceMemberCount(ws.Members().Count() + 1)


### PR DESCRIPTION
- The number of members of workspaces was not limited by policy. It was fixed.
- Fixed workspace to correctly use default policy.