### PR TITLE
chore: add asset type to data source manager

### DIFF
--- a/web/src/beta/features/Editor/DataSourceManager/Asset/index.tsx
+++ b/web/src/beta/features/Editor/DataSourceManager/Asset/index.tsx
@@ -146,7 +146,13 @@ const Asset: React.FC<DataProps> = ({ sceneId, onSubmit, onClose }) => {
               fileFormat={fileFormat}
               setFileFormat={(f: string) => setFileFormat(f as FileFormatType)}
             />
-            <URLField fileType="asset" name={t("Asset")} value={value} onChange={handleOnChange} />
+            <URLField
+              fileType="asset"
+              assetType={"file"}
+              name={t("Asset")}
+              value={value}
+              onChange={handleOnChange}
+            />
           </>
         )}
       </AssetWrapper>


### PR DESCRIPTION
# Overview
define the asset type as "file" so the asset modal only shows file types in data source manager.
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
