### PR TITLE
chore(web): customize file extension in upload file's window

### DIFF
--- a/web/src/beta/components/fields/URLField/index.tsx
+++ b/web/src/beta/components/fields/URLField/index.tsx
@@ -51,6 +51,7 @@ const URLField: React.FC<Props> = ({ name, description, value, fileType, assetTy
   const { handleFileUpload } = useFileUploaderHook({
     workspaceId: currentWorkspace?.id,
     onAssetSelect: handleChange,
+    assetType: assetType,
   });
 
   useEffect(() => {

--- a/web/src/beta/hooks/useAssetUploader/hooks.tsx
+++ b/web/src/beta/hooks/useAssetUploader/hooks.tsx
@@ -4,7 +4,7 @@ import useFileInput from "use-file-input";
 import { useAssetsFetcher } from "@reearth/services/api";
 
 import { FILE_FORMATS, IMAGE_FORMATS } from "../../features/Assets/constants";
-
+//pass the asset type
 export default ({
   workspaceId,
   onAssetSelect,

--- a/web/src/beta/hooks/useAssetUploader/hooks.tsx
+++ b/web/src/beta/hooks/useAssetUploader/hooks.tsx
@@ -1,18 +1,28 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import useFileInput from "use-file-input";
 
 import { useAssetsFetcher } from "@reearth/services/api";
 
 import { FILE_FORMATS, IMAGE_FORMATS } from "../../features/Assets/constants";
-//pass the asset type
+
 export default ({
   workspaceId,
   onAssetSelect,
+  assetType,
 }: {
   workspaceId?: string;
   onAssetSelect?: (inputValue?: string) => void;
+  assetType?: string;
 }) => {
   const { useCreateAssets } = useAssetsFetcher();
+
+  const acceptedExtension = useMemo(() => {
+    return assetType === "image"
+      ? IMAGE_FORMATS
+      : assetType === "file"
+      ? FILE_FORMATS
+      : IMAGE_FORMATS + "," + FILE_FORMATS;
+  }, [assetType]);
 
   const handleAssetsCreate = useCallback(
     async (files?: FileList) => {
@@ -25,7 +35,7 @@ export default ({
     [workspaceId, useCreateAssets, onAssetSelect],
   );
   const handleFileUpload = useFileInput(files => handleAssetsCreate?.(files), {
-    accept: IMAGE_FORMATS + "," + FILE_FORMATS,
+    accept: acceptedExtension,
     multiple: true,
   });
 


### PR DESCRIPTION
# Overview
When user presses on upload file , we customized what are the allowed extensions that he can upload them.
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
