### PR TITLE
chore(web): improve performance of flyTo

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/useEngineRef.ts
+++ b/web/src/beta/lib/core/engines/Cesium/useEngineRef.ts
@@ -137,7 +137,8 @@ export default function useEngineRef(
           if (!viewer || viewer.isDestroyed()) return;
 
           const layerOrFeatureId = target;
-          const entityFromFeatureId = findEntity(viewer, undefined, layerOrFeatureId);
+          const entityFromFeatureId = findEntity(viewer, undefined, layerOrFeatureId, true);
+          // `viewer.flyTo` doesn't support Cesium3DTileFeature.
           if (
             entityFromFeatureId &&
             !(

--- a/web/src/beta/lib/core/engines/Cesium/utils.ts
+++ b/web/src/beta/lib/core/engines/Cesium/utils.ts
@@ -139,6 +139,7 @@ export function findEntity(
   viewer: CesiumViewer,
   layerId?: string,
   featureId?: string,
+  withoutTileFeature?: boolean,
 ): Entity | Cesium3DTileset | InternalCesium3DTileFeature | undefined {
   const id = featureId ?? layerId;
   const keyName = featureId ? "featureId" : "layerId";
@@ -160,19 +161,6 @@ export function findEntity(
     }
   }
 
-  // Find Cesium3DTileFeature
-  for (let i = 0; i < viewer.scene.primitives.length; i++) {
-    const prim = viewer.scene.primitives.get(i);
-    if (!(prim instanceof Cesium3DTileset) || !prim.ready) {
-      continue;
-    }
-
-    const target = findFeatureFrom3DTile(prim.root, featureId);
-    if (target) {
-      return target;
-    }
-  }
-
   // Find Cesium3DTileset
   for (let i = 0; i < viewer.scene.primitives.length; i++) {
     const prim = viewer.scene.primitives.get(i);
@@ -180,12 +168,24 @@ export function findEntity(
       continue;
     }
 
-    const tag = getTag(prim);
-    if (tag?.layerId && layerId && tag?.layerId === layerId) {
-      return prim;
+    if (layerId && !featureId) {
+      const tag = getTag(prim);
+      if (tag?.layerId && layerId && tag?.layerId === layerId) {
+        return prim;
+      }
+      continue;
+    }
+
+    if (!prim.ready) continue;
+
+    // Skip to search 3dtiles features if `withoutTileFeature` is `true`.
+    if (!withoutTileFeature) {
+      const target = findFeatureFrom3DTile(prim.root, featureId);
+      if (target) {
+        return target;
+      }
     }
   }
-
   return;
 }
 


### PR DESCRIPTION
# Overview

In previous flyTo, this had searched all 3dtiles's features. However 3dtiles's feature can't flyTo automatically by Cesium. So we don't need to search it for flyTo. Therefore I fixed to skip the search process in flyTo.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
