### PR TITLE
chore(web): update default layer style

### DIFF
--- a/web/src/beta/utils/value.ts
+++ b/web/src/beta/utils/value.ts
@@ -230,6 +230,9 @@ export const zeroValues: { [key in ValueType]?: ValueTypes[ValueType] } = {
 };
 
 export const DEFAULT_LAYER_STYLE: Partial<LayerAppearanceTypes> = {
+  "3dtiles": {
+    show: true,
+  },
   resource: {
     clampToGround: true,
   },
@@ -241,5 +244,11 @@ export const DEFAULT_LAYER_STYLE: Partial<LayerAppearanceTypes> = {
   },
   polyline: {
     clampToGround: true,
+  },
+  model: {
+    heightReference: "clamp",
+  },
+  ellipsoid: {
+    heightReference: "clamp",
   },
 };


### PR DESCRIPTION
# Overview
This is PR updates the `DEFAULT_LAYER_STYLE`  utilised in converting the received layer from the backend to the visualizer processable format in Visualizer's `convert.ts`.

`"3dtiles"` default property has been added as `show: true` and `heightReference` has been set to 'clamp' for the `model` and `ellipsoid`.