### PR TITLE
chore(server): add play mode to timeline setting in manifest

### DIFF
--- a/server/pkg/builtin/manifest.yml
+++ b/server/pkg/builtin/manifest.yml
@@ -2508,6 +2508,16 @@ extensions:
               type: timeline
               ui: datetime
               title: Timeline Setting
+            - id: playMode
+              type: string
+              title: Play Mode
+              description: Specify play mode.
+              defaultValue: once
+              choices:
+                - key: once
+                  label: Once
+                - key: loop
+                  label: Loop
   - id: showLayersStoryBlock
     name: Show Layers
     type: storyBlock


### PR DESCRIPTION
# Overview
This adds Play Mode to Timeline Settings Story Block. With default value as `once` and choices given between `once` and `loop`.