### PR TITLE
chore(web): add consistency to react imports

### DIFF
--- a/web/src/beta/components/Popover/hooks.ts
+++ b/web/src/beta/components/Popover/hooks.ts
@@ -9,7 +9,7 @@ import {
   useInteractions,
   useRole,
 } from "@floating-ui/react";
-import * as React from "react";
+import { useState, useMemo } from "react";
 
 import { PopoverOptions } from "./types";
 
@@ -21,7 +21,7 @@ export default function usePopover({
   open: controlledOpen,
   onOpenChange: setControlledOpen,
 }: PopoverOptions = {}) {
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(initialOpen);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(initialOpen);
 
   const open = controlledOpen ?? uncontrolledOpen;
   const setOpen = setControlledOpen ?? setUncontrolledOpen;
@@ -52,7 +52,7 @@ export default function usePopover({
 
   const interactions = useInteractions([click, dismiss, role]);
 
-  return React.useMemo(
+  return useMemo(
     () => ({
       open,
       setOpen,

--- a/web/src/beta/components/Portal/index.tsx
+++ b/web/src/beta/components/Portal/index.tsx
@@ -1,8 +1,8 @@
-import React, { ReactNode, useLayoutEffect } from "react";
+import { ReactNode, useLayoutEffect, useState } from "react";
 import ReactDOM from "react-dom";
 
 const Portal: React.FC<{ children?: ReactNode }> = ({ children }) => {
-  const [node, setNode] = React.useState<HTMLElement>();
+  const [node, setNode] = useState<HTMLElement>();
 
   useLayoutEffect(() => {
     setNode(document.body);

--- a/web/src/beta/features/Editor/DataSourceManager/Common/index.tsx
+++ b/web/src/beta/features/Editor/DataSourceManager/Common/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import Button from "@reearth/beta/components/Button";
 import SelectField from "@reearth/beta/components/fields/SelectField";
@@ -39,10 +39,10 @@ const SelectDataType: React.FC<{ fileFormat: string; setFileFormat: (k: string) 
 
 const Asset: React.FC<DataProps> = ({ sceneId, onSubmit, onClose }) => {
   const t = useT();
-  const [sourceType, setSourceType] = React.useState<SourceType>("local");
-  const [fileFormat, setFileFormat] = React.useState<FileFormatType>("GeoJSON");
-  const [value, setValue] = React.useState("");
-  const [prioritizePerformance, setPrioritizePerformance] = React.useState(false);
+  const [sourceType, setSourceType] = useState<SourceType>("local");
+  const [fileFormat, setFileFormat] = useState<FileFormatType>("GeoJSON");
+  const [value, setValue] = useState("");
+  const [prioritizePerformance, setPrioritizePerformance] = useState(false);
   const DataSourceOptions: DataSourceOptType = useMemo(
     () => [
       { label: t("From Assets"), keyValue: "local" },

--- a/web/src/beta/features/Editor/DataSourceManager/DelimitedText/index.tsx
+++ b/web/src/beta/features/Editor/DataSourceManager/DelimitedText/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import Button from "@reearth/beta/components/Button";
 import URLField from "@reearth/beta/components/fields/URLField";
@@ -20,10 +20,10 @@ import {
 const DelimitedText: React.FC<DataProps> = ({ sceneId, onSubmit, onClose }) => {
   const t = useT();
 
-  const [sourceType, setSourceType] = React.useState<SourceType>("local");
-  const [value, setValue] = React.useState("");
-  const [lat, setLat] = React.useState("");
-  const [long, setLong] = React.useState("");
+  const [sourceType, setSourceType] = useState<SourceType>("local");
+  const [value, setValue] = useState("");
+  const [lat, setLat] = useState("");
+  const [long, setLong] = useState("");
 
   const DataSourceOptions: DataSourceOptType = useMemo(
     () => [

--- a/web/src/beta/features/Editor/DataSourceManager/ThreeDTiles/index.tsx
+++ b/web/src/beta/features/Editor/DataSourceManager/ThreeDTiles/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { useState } from "react";
 
 import Button from "@reearth/beta/components/Button";
 
@@ -13,7 +13,7 @@ import {
 } from "../utils";
 
 const ThreeDTiles: React.FC<DataProps> = ({ sceneId, onSubmit, onClose }) => {
-  const [value, setValue] = React.useState("");
+  const [value, setValue] = useState("");
 
   const handleSubmit = () => {
     onSubmit({

--- a/web/src/beta/lib/lexical/RichTextEditor/ui/DropDown.tsx
+++ b/web/src/beta/lib/lexical/RichTextEditor/ui/DropDown.tsx
@@ -1,12 +1,20 @@
-import * as React from "react";
-import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useContext,
+  createContext,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 
 type DropDownContextType = {
   registerItem: (ref: React.RefObject<HTMLButtonElement>) => void;
 };
 
-const DropDownContext = React.createContext<DropDownContextType | null>(null);
+const DropDownContext = createContext<DropDownContextType | null>(null);
 
 const dropDownPadding = 4;
 
@@ -23,7 +31,7 @@ export function DropDownItem({
 }) {
   const ref = useRef<HTMLButtonElement>(null);
 
-  const dropDownContext = React.useContext(DropDownContext);
+  const dropDownContext = useContext(DropDownContext);
 
   if (dropDownContext === null) {
     throw new Error("DropDownItem must be used within a DropDown");


### PR DESCRIPTION
# Overview
This is a small refactor PR which attempts to make consistent way of import React related function into Beta. quick example being `useState` and `useMemo`.
 