### PR TITLE
chore(web): fix mvt layer behaviour

### DIFF
--- a/web/src/beta/features/Editor/DataSourceManager/VectorTiles/index.tsx
+++ b/web/src/beta/features/Editor/DataSourceManager/VectorTiles/index.tsx
@@ -53,7 +53,7 @@ const VectorTiles: FC<DataProps> = ({ sceneId, onSubmit, onClose }) => {
         data: {
           url: urlValue !== "" ? urlValue : undefined,
           type: "mvt",
-          layers: layers.length === 1 ? layers[0] : layers,
+          layers: updatedLayers.length === 1 ? updatedLayers[0] : updatedLayers,
         },
       },
     });


### PR DESCRIPTION
# Overview
This PR fixes an oversight made with https://github.com/reearth/reearth/pull/706 which lead to MVT layer adding behaviour not being on par.
