### PR TITLE
chore(web): add height to marker appearance

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/Feature/Marker/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Marker/index.tsx
@@ -29,7 +29,7 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
     () =>
       geometry?.type === "Point"
         ? property?.height
-          ? [...geometry.coordinates, property.height]
+          ? [...geometry.coordinates.slice(0, 2), property.height]
           : geometry.coordinates
         : property?.location
         ? [property.location.lng, property.location.lat, property.height ?? 0]

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Marker/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Marker/index.tsx
@@ -28,7 +28,9 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
   const coordinates = useMemo(
     () =>
       geometry?.type === "Point"
-        ? geometry.coordinates
+        ? property?.height
+          ? [...geometry.coordinates, property.height]
+          : geometry.coordinates
         : property?.location
         ? [property.location.lng, property.location.lat, property.height ?? 0]
         : undefined,

--- a/web/src/beta/lib/core/mantle/types/appearance.ts
+++ b/web/src/beta/lib/core/mantle/types/appearance.ts
@@ -32,6 +32,7 @@ export type AppearanceTypes = {
 
 export type MarkerAppearance = {
   show?: boolean;
+  height?: number;
   heightReference?: "none" | "clamp" | "relative";
   style?: "none" | "point" | "image";
   pointSize?: number;


### PR DESCRIPTION
# Overview
This PR adds support for `height` as a possible parameter for marker's appearance. After this change the user can directly add and adjust `height` through the style code.