### PR TITLE
chore(web): handle misfiring of singleClick on doubleClick at layerName and layerStyleName

### DIFF
--- a/web/src/beta/features/Editor/tabs/map/BottomPanel/LayerStyleCard.tsx
+++ b/web/src/beta/features/Editor/tabs/map/BottomPanel/LayerStyleCard.tsx
@@ -32,8 +32,26 @@ const LayerStyleCard: React.FC<Props> = ({
   const [isHovered, setIsHovered] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [newName, setNewName] = useState(name);
+  const [clickTimeoutId, setClickTimeoutId] = useState<any>(null);
 
-  const handleNameClick = useCallback(() => setIsEditing(true), []);
+  const handleClick = useCallback(() => {
+    if (clickTimeoutId !== null) {
+      clearTimeout(clickTimeoutId);
+      setClickTimeoutId(null);
+    }
+    const timeoutId = window.setTimeout(() => {
+      onSelect?.(!selected);
+    }, 300);
+    setClickTimeoutId(timeoutId);
+  }, [clickTimeoutId, onSelect, selected]);
+
+  const handleNameClick = useCallback(() => {
+    if (clickTimeoutId !== null) {
+      clearTimeout(clickTimeoutId);
+      setClickTimeoutId(null);
+    }
+    setIsEditing(true);
+  }, [clickTimeoutId]);
 
   const handleMouseEnter = useCallback(() => {
     setIsHovered(true);
@@ -77,7 +95,7 @@ const LayerStyleCard: React.FC<Props> = ({
     <Wrapper
       className={className}
       selected={selected}
-      onClick={() => onSelect?.(!selected)}
+      onClick={handleClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}>
       <MainWrapper>
@@ -181,4 +199,9 @@ const StyleName = styled(Text)`
 
 const StyledTextInput = styled(TextInput)`
   width: 100%;
+  font-size: 12px;
+  color: ${({ theme }) => theme.content.main};
+  font-style: normal;
+  font-weight: 400;
+  line-height: 20px;
 `;

--- a/web/src/beta/features/Editor/tabs/map/BottomPanel/LayerStyleCard.tsx
+++ b/web/src/beta/features/Editor/tabs/map/BottomPanel/LayerStyleCard.tsx
@@ -41,7 +41,7 @@ const LayerStyleCard: React.FC<Props> = ({
     }
     const timeoutId = window.setTimeout(() => {
       onSelect?.(!selected);
-    }, 300);
+    }, 200);
     setClickTimeoutId(timeoutId);
   }, [clickTimeoutId, onSelect, selected]);
 

--- a/web/src/beta/features/Editor/tabs/map/LeftPanel/Layers/LayerItem.tsx
+++ b/web/src/beta/features/Editor/tabs/map/LeftPanel/Layers/LayerItem.tsx
@@ -36,26 +36,36 @@ const LayerItem = ({
   const [newValue, setNewValue] = useState(layerTitle);
   const [isVisible, setIsVisible] = useState(visible);
   const [value, setValue] = useState(isVisible ? "V" : "");
+  const [clickTimeoutId, setClickTimeoutId] = useState<any>(null);
 
   const handleActionMenuToggle = useCallback(() => setActionOpen(prev => !prev), []);
 
-  const handleClick = useCallback(
-    (e?: MouseEvent<Element>) => {
-      if (e?.shiftKey) {
-        e?.stopPropagation();
-        setIsEditing(true);
-        return;
-      }
+  const handleClick = useCallback(() => {
+    if (clickTimeoutId) {
+      clearTimeout(clickTimeoutId);
+      setClickTimeoutId(null);
+    }
+    const timeoutId = setTimeout(() => {
       onSelect();
-    },
-    [onSelect],
-  );
+    }, 200);
+    setClickTimeoutId(timeoutId);
+  }, [onSelect, clickTimeoutId]);
+
+  const handleLayerTitleClick = useCallback(() => {
+    if (clickTimeoutId) {
+      clearTimeout(clickTimeoutId);
+      setClickTimeoutId(null);
+    }
+    setIsEditing(true);
+  }, [clickTimeoutId]);
 
   const handleChange = useCallback((newTitle: string) => setNewValue(newTitle), []);
 
   const handleTitleSubmit = useCallback(() => {
     setIsEditing(false);
-    onLayerNameUpdate({ layerId: id, name: newValue });
+    if (newValue.trim() !== "") {
+      onLayerNameUpdate({ layerId: id, name: newValue });
+    }
   }, [id, newValue, onLayerNameUpdate]);
 
   const handleEditExit = useCallback(
@@ -103,7 +113,7 @@ const LayerItem = ({
       }>
       <ContentWrapper>
         {isEditing ? (
-          <TextInput
+          <StyledTextInput
             value={newValue}
             timeout={0}
             autoFocus
@@ -112,7 +122,7 @@ const LayerItem = ({
             onBlur={handleEditExit}
           />
         ) : (
-          <LayerTitle>{layerTitle}</LayerTitle>
+          <LayerTitle onDoubleClick={handleLayerTitleClick}>{layerTitle}</LayerTitle>
         )}
         <HideLayer onClick={handleUpdateVisibility}>
           <Text size="footnote">{value}</Text>
@@ -156,4 +166,13 @@ const HideLayer = styled.div`
   :hover {
     background: ${({ theme }) => theme.bg[2]};
   }
+`;
+
+const StyledTextInput = styled(TextInput)`
+  width: 100%;
+  font-size: 12px;
+  color: ${({ theme }) => theme.content.main};
+  font-style: normal;
+  font-weight: 400;
+  line-height: 20px;
 `;


### PR DESCRIPTION
# Overview
This PR changes the behaviour to editing the layerName on the leftPanel from SHIFT+Click to DoubleClick to go on editing mode and fix misfiring of single click when attempting to make a doubleClick by introducing debouncing in both LayerItem and LayerStyleCard component.
