### PR TITLE
chore(web): fix gap field component

### DIFF
--- a/web/src/beta/lib/core/StoryPanel/ActionPanel/index.tsx
+++ b/web/src/beta/lib/core/StoryPanel/ActionPanel/index.tsx
@@ -50,7 +50,6 @@ const ActionPanel: React.FC<Props> = ({
 }) => {
   const t = useT();
   const ref = useItemContext();
-
   const handleRemove = useCallback(() => {
     onRemove?.();
     onSettingsToggle?.();
@@ -75,7 +74,6 @@ const ActionPanel: React.FC<Props> = ({
     }
     return menuItems;
   }, [settingsTitle, t, setShowPadding, onRemove, handleRemove]);
-  // console.log("PS", panelSettings);
 
   return (
     <Wrapper isSelected={isSelected} position={position} onClick={stopClickPropagation}>
@@ -120,12 +118,12 @@ const ActionPanel: React.FC<Props> = ({
               </SettingsHeading>
               {propertyId && panelSettings && (
                 <SettingsContent>
-                  {Object.keys(panelSettings).map(fieldId => {
+                  {Object.keys(panelSettings).map((fieldId, index) => {
                     const field = panelSettings[fieldId];
                     const groupId = "panel";
                     return (
                       <FieldComponent
-                        key={groupId + propertyId}
+                        key={index}
                         propertyId={propertyId}
                         groupId={groupId}
                         fieldId={fieldId}

--- a/web/src/beta/lib/core/StoryPanel/Page/hooks.ts
+++ b/web/src/beta/lib/core/StoryPanel/Page/hooks.ts
@@ -43,7 +43,6 @@ export default ({
   const property = useMemo(() => page?.property, [page?.property]);
 
   const propertyId = useMemo(() => page?.propertyId, [page?.propertyId]);
-
   const panelSettings = useMemo(
     () => ({
       padding: {
@@ -55,10 +54,10 @@ export default ({
         ),
       },
       gap: {
+        ...property?.panel?.gap,
         value:
-          property?.panel?.gap?.value ?? isEditable
-            ? MIN_STORY_PAGE_GAP_IN_EDITOR
-            : DEFAULT_STORY_PAGE_GAP,
+          property?.panel?.gap?.value ??
+          (isEditable ? MIN_STORY_PAGE_GAP_IN_EDITOR : DEFAULT_STORY_PAGE_GAP),
       },
     }),
     [property?.panel, isEditable],


### PR DESCRIPTION
# Overview
- Fix the gap field component in page action panel , moving from this 
![image](https://github.com/reearth/reearth/assets/89770889/7eb81646-54fb-4905-8197-17598c40ea7b)
To this 
![image](https://github.com/reearth/reearth/assets/89770889/b9f0d3d5-e620-4c44-a06d-0a7f8933988f)
- Fix  the unique key warning 
## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
