### PR TITLE
chore(web): add an API to get description from entity

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/Feature/Resource/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Resource/index.tsx
@@ -81,7 +81,7 @@ export default function Resource({
       const features: Feature[] = [];
       const computedFeatures: ComputedFeature[] = [];
       e.entities.values.forEach(e => {
-        const res = attachStyle(e, layer, evalFeature, viewer);
+        const res = attachStyle(e, layer, evalFeature, viewer.clock.currentTime);
         const [feature, computedFeature] = res || [];
 
         attachTag(e, { layerId: layer?.id, featureId: feature?.id });
@@ -167,7 +167,7 @@ export default function Resource({
   useEffect(() => {
     if (!viewer) return;
     cachedFeatures.current.forEach(f => {
-      attachStyle(f.raw, layer, evalFeature, viewer);
+      attachStyle(f.raw, layer, evalFeature, viewer.clock.currentTime);
     });
   }, [layer, viewer]);
 

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Resource/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Resource/index.tsx
@@ -81,7 +81,7 @@ export default function Resource({
       const features: Feature[] = [];
       const computedFeatures: ComputedFeature[] = [];
       e.entities.values.forEach(e => {
-        const res = attachStyle(e, layer, evalFeature, viewer.clock.currentTime);
+        const res = attachStyle(e, layer, evalFeature, viewer);
         const [feature, computedFeature] = res || [];
 
         attachTag(e, { layerId: layer?.id, featureId: feature?.id });
@@ -167,7 +167,7 @@ export default function Resource({
   useEffect(() => {
     if (!viewer) return;
     cachedFeatures.current.forEach(f => {
-      attachStyle(f.raw, layer, evalFeature, viewer.clock.currentTime);
+      attachStyle(f.raw, layer, evalFeature, viewer);
     });
   }, [layer, viewer]);
 

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Resource/utils.ts
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Resource/utils.ts
@@ -142,7 +142,9 @@ export const attachStyle = (
         coordinates,
       },
       properties: convertEntityProperties(currentTime, entity),
-      description: convertEntityDescription(currentTime, entity),
+      metaData: {
+        description: convertEntityDescription(currentTime, entity),
+      },
       range: {
         x: coordinates[0],
         y: coordinates[1],
@@ -274,7 +276,9 @@ export const attachStyle = (
         coordinates,
       },
       properties: convertEntityProperties(currentTime, entity),
-      description: convertEntityDescription(currentTime, entity),
+      metaData: {
+        description: convertEntityDescription(currentTime, entity),
+      },
       range: {
         x: entityPosition?.x ?? 0,
         y: entityPosition?.y ?? 0,
@@ -322,7 +326,9 @@ export const attachStyle = (
         coordinates,
       },
       properties: convertEntityProperties(currentTime, entity),
-      description: convertEntityDescription(currentTime, entity),
+      metaData: {
+        description: convertEntityDescription(currentTime, entity),
+      },
       range: {
         x: entityPosition?.x ?? 0,
         y: entityPosition?.y ?? 0,

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Resource/utils.ts
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Resource/utils.ts
@@ -1,10 +1,10 @@
 import {
-  JulianDate,
   Entity,
   Cartesian3,
   PolygonHierarchy,
   PointGraphics,
   BillboardGraphics,
+  Viewer,
 } from "cesium";
 
 import {
@@ -16,6 +16,7 @@ import {
 import { EvalFeature } from "@reearth/beta/lib/core/Map";
 
 import { heightReference, shadowMode, toColor } from "../../common";
+import { convertEntityDescription, convertEntityProperties } from "../../utils";
 import { attachTag, extractSimpleLayer, getTag, Tag } from "../utils";
 
 export function overrideOriginalProperties(
@@ -120,7 +121,7 @@ export const attachStyle = (
   entity: Entity,
   layer: ComputedLayer | undefined,
   evalFeature: EvalFeature,
-  currentTime: JulianDate,
+  viewer: Viewer,
 ): [Feature, ComputedFeature] | void => {
   if (!layer) {
     return;
@@ -131,7 +132,7 @@ export const attachStyle = (
   const billboard = hasAppearance(layer, entity, ["marker", "billboard"]);
   const label = hasAppearance(layer, entity, ["marker", "label"]);
   if (point || billboard || label) {
-    const position = entity.position?.getValue(currentTime);
+    const position = entity.position?.getValue(viewer.clock.currentTime);
     const coordinates = [position?.x ?? 0, position?.y ?? 0, position?.z ?? 0];
     const feature: Feature = {
       type: "feature",
@@ -140,7 +141,8 @@ export const attachStyle = (
         type: "Point",
         coordinates,
       },
-      properties: entity.properties?.getValue(currentTime) || {},
+      properties: convertEntityProperties(viewer, entity),
+      description: convertEntityDescription(viewer, entity),
       range: {
         x: coordinates[0],
         y: coordinates[1],
@@ -257,8 +259,10 @@ export const attachStyle = (
   }
 
   if (hasAppearance(layer, entity, ["polyline", "polyline"])) {
-    const entityPosition = entity.position?.getValue(currentTime);
-    const positions = entity.polyline?.positions?.getValue(currentTime) as Cartesian3[];
+    const entityPosition = entity.position?.getValue(viewer.clock.currentTime);
+    const positions = entity.polyline?.positions?.getValue(
+      viewer.clock.currentTime,
+    ) as Cartesian3[];
     const coordinates = positions?.map(position => [
       position?.x ?? 0,
       position?.y ?? 0,
@@ -271,7 +275,8 @@ export const attachStyle = (
         type: "LineString",
         coordinates,
       },
-      properties: entity.properties?.getValue(currentTime) || {},
+      properties: convertEntityProperties(viewer, entity),
+      description: convertEntityDescription(viewer, entity),
       range: {
         x: entityPosition?.x ?? 0,
         y: entityPosition?.y ?? 0,
@@ -306,8 +311,10 @@ export const attachStyle = (
   }
 
   if (hasAppearance(layer, entity, ["polygon", "polygon"])) {
-    const entityPosition = entity.position?.getValue(currentTime);
-    const hierarchy = entity.polygon?.hierarchy?.getValue(currentTime) as PolygonHierarchy;
+    const entityPosition = entity.position?.getValue(viewer.clock.currentTime);
+    const hierarchy = entity.polygon?.hierarchy?.getValue(
+      viewer.clock.currentTime,
+    ) as PolygonHierarchy;
     const coordinates = hierarchy?.holes?.map(hole =>
       hole.positions.map(position => [position?.x ?? 0, position?.y ?? 0, position?.z ?? 0]),
     );
@@ -318,7 +325,8 @@ export const attachStyle = (
         type: "Polygon",
         coordinates,
       },
-      properties: entity.properties?.getValue(currentTime) || {},
+      properties: convertEntityProperties(viewer, entity),
+      description: convertEntityDescription(viewer, entity),
       range: {
         x: entityPosition?.x ?? 0,
         y: entityPosition?.y ?? 0,

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Resource/utils.ts
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Resource/utils.ts
@@ -4,7 +4,7 @@ import {
   PolygonHierarchy,
   PointGraphics,
   BillboardGraphics,
-  Viewer,
+  JulianDate,
 } from "cesium";
 
 import {
@@ -121,7 +121,7 @@ export const attachStyle = (
   entity: Entity,
   layer: ComputedLayer | undefined,
   evalFeature: EvalFeature,
-  viewer: Viewer,
+  currentTime: JulianDate,
 ): [Feature, ComputedFeature] | void => {
   if (!layer) {
     return;
@@ -132,7 +132,7 @@ export const attachStyle = (
   const billboard = hasAppearance(layer, entity, ["marker", "billboard"]);
   const label = hasAppearance(layer, entity, ["marker", "label"]);
   if (point || billboard || label) {
-    const position = entity.position?.getValue(viewer.clock.currentTime);
+    const position = entity.position?.getValue(currentTime);
     const coordinates = [position?.x ?? 0, position?.y ?? 0, position?.z ?? 0];
     const feature: Feature = {
       type: "feature",
@@ -141,8 +141,8 @@ export const attachStyle = (
         type: "Point",
         coordinates,
       },
-      properties: convertEntityProperties(viewer, entity),
-      description: convertEntityDescription(viewer, entity),
+      properties: convertEntityProperties(currentTime, entity),
+      description: convertEntityDescription(currentTime, entity),
       range: {
         x: coordinates[0],
         y: coordinates[1],
@@ -259,10 +259,8 @@ export const attachStyle = (
   }
 
   if (hasAppearance(layer, entity, ["polyline", "polyline"])) {
-    const entityPosition = entity.position?.getValue(viewer.clock.currentTime);
-    const positions = entity.polyline?.positions?.getValue(
-      viewer.clock.currentTime,
-    ) as Cartesian3[];
+    const entityPosition = entity.position?.getValue(currentTime);
+    const positions = entity.polyline?.positions?.getValue(currentTime) as Cartesian3[];
     const coordinates = positions?.map(position => [
       position?.x ?? 0,
       position?.y ?? 0,
@@ -275,8 +273,8 @@ export const attachStyle = (
         type: "LineString",
         coordinates,
       },
-      properties: convertEntityProperties(viewer, entity),
-      description: convertEntityDescription(viewer, entity),
+      properties: convertEntityProperties(currentTime, entity),
+      description: convertEntityDescription(currentTime, entity),
       range: {
         x: entityPosition?.x ?? 0,
         y: entityPosition?.y ?? 0,
@@ -311,10 +309,8 @@ export const attachStyle = (
   }
 
   if (hasAppearance(layer, entity, ["polygon", "polygon"])) {
-    const entityPosition = entity.position?.getValue(viewer.clock.currentTime);
-    const hierarchy = entity.polygon?.hierarchy?.getValue(
-      viewer.clock.currentTime,
-    ) as PolygonHierarchy;
+    const entityPosition = entity.position?.getValue(currentTime);
+    const hierarchy = entity.polygon?.hierarchy?.getValue(currentTime) as PolygonHierarchy;
     const coordinates = hierarchy?.holes?.map(hole =>
       hole.positions.map(position => [position?.x ?? 0, position?.y ?? 0, position?.z ?? 0]),
     );
@@ -325,8 +321,8 @@ export const attachStyle = (
         type: "Polygon",
         coordinates,
       },
-      properties: convertEntityProperties(viewer, entity),
-      description: convertEntityDescription(viewer, entity),
+      properties: convertEntityProperties(currentTime, entity),
+      description: convertEntityDescription(currentTime, entity),
       range: {
         x: entityPosition?.x ?? 0,
         y: entityPosition?.y ?? 0,

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Tileset/hooks.ts
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Tileset/hooks.ts
@@ -186,9 +186,7 @@ const useFeature = ({
         const raw = feature.raw;
         const tag = getTag(raw);
         const properties =
-          viewer && !(raw instanceof Model)
-            ? convertCesium3DTileFeatureProperties(viewer, raw)
-            : {};
+          viewer && !(raw instanceof Model) ? convertCesium3DTileFeatureProperties(raw) : {};
 
         const computedFeature = evalFeature(layer, { ...feature?.feature, properties });
 

--- a/web/src/beta/lib/core/engines/Cesium/pickMany.ts
+++ b/web/src/beta/lib/core/engines/Cesium/pickMany.ts
@@ -294,7 +294,7 @@ export const pickManyFromViewportAsFeature = (
 
   const result = [];
   for (const obj of objs) {
-    const [layerId, f] = convertObjToComputedFeature(viewer, obj) ?? [];
+    const [layerId, f] = convertObjToComputedFeature(viewer.clock.currentTime, obj) ?? [];
     const pickedFeature = f ? { ...f, layerId } : undefined;
     if (!pickedFeature || (condition && !condition(pickedFeature))) {
       continue;

--- a/web/src/beta/lib/core/engines/Cesium/useEngineRef.ts
+++ b/web/src/beta/lib/core/engines/Cesium/useEngineRef.ts
@@ -35,6 +35,7 @@ import { attachTag, getTag } from "./Feature";
 import { PickedFeature, pickManyFromViewportAsFeature } from "./pickMany";
 import {
   convertCesium3DTileFeatureProperties,
+  convertEntityDescription,
   convertEntityProperties,
   convertObjToComputedFeature,
   findEntity,
@@ -497,6 +498,7 @@ export default function useEngineRef(
             type: "feature",
             id: tag.featureId,
             properties: convertEntityProperties(viewer, entity),
+            description: convertEntityDescription(viewer, entity),
           };
         }
         if (
@@ -542,6 +544,7 @@ export default function useEngineRef(
               type: "computedFeature",
               id: tag.featureId,
               properties: convertEntityProperties(viewer, entity),
+              description: convertEntityDescription(viewer, entity),
             }
           );
         }

--- a/web/src/beta/lib/core/engines/Cesium/useEngineRef.ts
+++ b/web/src/beta/lib/core/engines/Cesium/useEngineRef.ts
@@ -498,7 +498,9 @@ export default function useEngineRef(
             type: "feature",
             id: tag.featureId,
             properties: convertEntityProperties(viewer.clock.currentTime, entity),
-            description: convertEntityDescription(viewer.clock.currentTime, entity),
+            metaData: {
+              description: convertEntityDescription(viewer.clock.currentTime, entity),
+            },
           };
         }
         if (
@@ -544,7 +546,9 @@ export default function useEngineRef(
               type: "computedFeature",
               id: tag.featureId,
               properties: convertEntityProperties(viewer.clock.currentTime, entity),
-              description: convertEntityDescription(viewer.clock.currentTime, entity),
+              metaData: {
+                description: convertEntityDescription(viewer.clock.currentTime, entity),
+              },
             }
           );
         }

--- a/web/src/beta/lib/core/engines/Cesium/useEngineRef.ts
+++ b/web/src/beta/lib/core/engines/Cesium/useEngineRef.ts
@@ -497,8 +497,8 @@ export default function useEngineRef(
           return {
             type: "feature",
             id: tag.featureId,
-            properties: convertEntityProperties(viewer, entity),
-            description: convertEntityDescription(viewer, entity),
+            properties: convertEntityProperties(viewer.clock.currentTime, entity),
+            description: convertEntityDescription(viewer.clock.currentTime, entity),
           };
         }
         if (
@@ -508,7 +508,7 @@ export default function useEngineRef(
           return {
             type: "feature",
             id: tag.featureId,
-            properties: convertCesium3DTileFeatureProperties(viewer, entity),
+            properties: convertCesium3DTileFeatureProperties(entity),
           };
         }
         return;
@@ -517,7 +517,7 @@ export default function useEngineRef(
         const viewer = cesium.current?.cesiumElement;
         if (!viewer || viewer.isDestroyed()) return;
         return findFeaturesFromLayer(viewer, layerId, featureIds, e => {
-          const f = convertObjToComputedFeature(viewer, e)?.[1];
+          const f = convertObjToComputedFeature(viewer.clock.currentTime, e)?.[1];
           return f
             ? ({
                 ...f,
@@ -543,8 +543,8 @@ export default function useEngineRef(
             tag.computedFeature ?? {
               type: "computedFeature",
               id: tag.featureId,
-              properties: convertEntityProperties(viewer, entity),
-              description: convertEntityDescription(viewer, entity),
+              properties: convertEntityProperties(viewer.clock.currentTime, entity),
+              description: convertEntityDescription(viewer.clock.currentTime, entity),
             }
           );
         }
@@ -556,7 +556,7 @@ export default function useEngineRef(
             tag.computedFeature ?? {
               type: "computedFeature",
               id: tag.featureId,
-              properties: convertCesium3DTileFeatureProperties(viewer, entity),
+              properties: convertCesium3DTileFeatureProperties(entity),
             }
           );
         }
@@ -572,7 +572,7 @@ export default function useEngineRef(
           viewer,
           layerId,
           featureIds,
-          e => convertObjToComputedFeature(viewer, e)?.[1],
+          e => convertObjToComputedFeature(viewer.clock.currentTime, e)?.[1],
         );
       },
       selectFeatures: (layerId: string, featureId: string[]) => {

--- a/web/src/beta/lib/core/engines/Cesium/utils.ts
+++ b/web/src/beta/lib/core/engines/Cesium/utils.ts
@@ -322,15 +322,16 @@ export function getPixelRatio(scene: Scene): number {
 }
 
 export const convertEntityProperties = (viewer: Viewer, entity: Entity) => {
-  return (
-    entity.properties &&
-    Object.fromEntries(
-      entity.properties.propertyNames.map(key => [
-        key,
-        entity.properties?.getValue(viewer.clock.currentTime)?.[key],
-      ]),
-    )
-  );
+  const properties = entity.properties?.getValue(viewer.clock.currentTime);
+  return entity.properties && properties
+    ? Object.fromEntries(entity.properties.propertyNames.map(key => [key, properties[key]]))
+    : {};
+};
+
+export const convertEntityDescription = (viewer: Viewer, entity: Entity): string | undefined => {
+  const description = entity.description?.getValue(viewer.clock.currentTime);
+  if (typeof description !== "string") return;
+  return description;
 };
 
 export const convertCesium3DTileFeatureProperties = (

--- a/web/src/beta/lib/core/engines/Cesium/utils.ts
+++ b/web/src/beta/lib/core/engines/Cesium/utils.ts
@@ -380,7 +380,9 @@ export const convertObjToComputedFeature = (
         type: "computedFeature",
         id: tag?.featureId ?? "",
         properties: convertEntityProperties(currentTime, entity),
-        description: convertEntityDescription(currentTime, entity),
+        metaData: {
+          description: convertEntityDescription(currentTime, entity),
+        },
       },
     ];
   }

--- a/web/src/beta/lib/core/engines/Cesium/utils.ts
+++ b/web/src/beta/lib/core/engines/Cesium/utils.ts
@@ -321,28 +321,30 @@ export function getPixelRatio(scene: Scene): number {
   ).pixelRatio;
 }
 
-export const convertEntityProperties = (viewer: Viewer, entity: Entity) => {
-  const properties = entity.properties?.getValue(viewer.clock.currentTime);
+export const convertEntityProperties = (currentTime: JulianDate, entity: Entity) => {
+  const properties = entity.properties?.getValue(currentTime);
   return entity.properties && properties
     ? Object.fromEntries(entity.properties.propertyNames.map(key => [key, properties[key]]))
     : {};
 };
 
-export const convertEntityDescription = (viewer: Viewer, entity: Entity): string | undefined => {
-  const description = entity.description?.getValue(viewer.clock.currentTime);
+export const convertEntityDescription = (
+  currentTime: JulianDate,
+  entity: Entity,
+): string | undefined => {
+  const description = entity.description?.getValue(currentTime);
   if (typeof description !== "string") return;
   return description;
 };
 
 export const convertCesium3DTileFeatureProperties = (
-  viewer: Viewer,
   feature: Cesium3DTileFeature | Cesium3DTilePointFeature,
 ) => {
   return Object.fromEntries(feature.getPropertyIds().map(id => [id, feature.getProperty(id)]));
 };
 
 export const convertObjToComputedFeature = (
-  viewer: Viewer,
+  currentTime: JulianDate,
   obj: object,
 ): [layerId: string | undefined, feature: ComputedFeature] | undefined => {
   if (obj instanceof Cesium3DTileFeature || obj instanceof Cesium3DTilePointFeature) {
@@ -352,7 +354,7 @@ export const convertObjToComputedFeature = (
       tag?.computedFeature ?? {
         type: "computedFeature",
         id: tag?.featureId ?? "",
-        properties: convertCesium3DTileFeatureProperties(viewer, obj),
+        properties: convertCesium3DTileFeatureProperties(obj),
       },
     ];
   }
@@ -377,7 +379,8 @@ export const convertObjToComputedFeature = (
       tag?.computedFeature ?? {
         type: "computedFeature",
         id: tag?.featureId ?? "",
-        properties: convertEntityProperties(viewer, entity),
+        properties: convertEntityProperties(currentTime, entity),
+        description: convertEntityDescription(currentTime, entity),
       },
     ];
   }

--- a/web/src/beta/lib/core/mantle/types/index.ts
+++ b/web/src/beta/lib/core/mantle/types/index.ts
@@ -123,7 +123,10 @@ export type CommonFeature<T extends "feature" | "computedFeature"> = {
   geometry?: Geometry;
   interval?: TimeInterval;
   properties?: any;
-  description?: string;
+  // Map engine specific information.
+  metaData?: {
+    description?: string;
+  };
   range?: DataRange;
 };
 

--- a/web/src/beta/lib/core/mantle/types/index.ts
+++ b/web/src/beta/lib/core/mantle/types/index.ts
@@ -123,6 +123,7 @@ export type CommonFeature<T extends "feature" | "computedFeature"> = {
   geometry?: Geometry;
   interval?: TimeInterval;
   properties?: any;
+  description?: string;
   range?: DataRange;
 };
 


### PR DESCRIPTION
# Overview

I added this to display the description on VIEW3.0 feature inspector. 

## What I've done

## What I haven't done

## How I tested

Run this script to test this PR.
```
const layerId = reearth.layers.add({
    type: "simple",
    data: {
        type: "czml",
        url: "https://d2jfi34fqvxlsc.cloudfront.net/main/data/czml/landmark/01100_sapporo/hospital.czml"
    },
    marker: {
    }
});
setTimeout(() => reearth.camera.flyTo(layerId), 10);
console.log(reearth.layers.layers[0].computed.features); // You can see that each feature has the description.
```

## Which point I want you to review particularly

## Memo
