### PR TITLE
fix(chore): invoke requestRender in primitive features whenever component is updated

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/Feature/Marker/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Marker/index.tsx
@@ -1,11 +1,12 @@
 import { Cartesian3, Color, HorizontalOrigin, VerticalOrigin, Cartesian2 } from "cesium";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { BillboardGraphics, PointGraphics, LabelGraphics, PolylineGraphics } from "resium";
 
 import { toCSSFont } from "@reearth/beta/utils/value";
 
 import type { MarkerAppearance } from "../../..";
 import { useIcon, ho, vo, heightReference, toColor } from "../../common";
+import { useContext } from "../context";
 import {
   EntityExt,
   toDistanceDisplayCondition,
@@ -36,6 +37,8 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
         : undefined,
     [geometry?.coordinates, geometry?.type, property?.height, property?.location],
   );
+
+  const { requestRender } = useContext();
 
   const {
     show = true,
@@ -133,6 +136,10 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
     () => toDistanceDisplayCondition(property?.near, property?.far),
     [property?.near, property?.far],
   );
+
+  useEffect(() => {
+    requestRender?.();
+  });
 
   return !pos || !isVisible || !show ? null : (
     <>

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Model/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Model/index.tsx
@@ -176,6 +176,10 @@ export default function Model({
     }
   }, [imageBasedLighting]);
 
+  useEffect(() => {
+    requestRender?.();
+  });
+
   // if data type is gltf, layer should be rendered. Otherwise only features should be rendererd.
   return (isGltfData ? feature : !feature) || !isVisible || !show || !actualUrl ? null : (
     <EntityExt

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Polygon/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Polygon/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { Cartesian3, PolygonHierarchy } from "cesium";
 import { isEqual } from "lodash-es";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { Entity, PolygonGraphics, PolylineGraphics } from "resium";
 import { useCustomCompareMemo } from "use-custom-compare";
 
@@ -9,6 +9,7 @@ import { Polygon as PolygonValue, toColor } from "@reearth/beta/utils/value";
 
 import type { PolygonAppearance } from "../../..";
 import { classificationType, heightReference, shadowMode } from "../../common";
+import { useContext } from "../context";
 import {
   EntityExt,
   toDistanceDisplayCondition,
@@ -41,6 +42,8 @@ export default function Polygon({
         : undefined,
     [geometry?.coordinates, geometry?.type, property?.polygon],
   );
+
+  const { requestRender } = useContext();
 
   const {
     show = true,
@@ -106,6 +109,10 @@ export default function Polygon({
     () => toDistanceDisplayCondition(property?.near, property?.far),
     [property?.near, property?.far],
   );
+
+  useEffect(() => {
+    requestRender?.();
+  });
 
   return !isVisible || !coordiantes || !show ? null : (
     <>

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Polyline/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Polyline/index.tsx
@@ -1,6 +1,6 @@
 import { Cartesian3 } from "cesium";
 import { isEqual } from "lodash-es";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { PolylineGraphics } from "resium";
 import { useCustomCompareMemo } from "use-custom-compare";
 
@@ -8,6 +8,7 @@ import { Coordinates, toColor } from "@reearth/beta/utils/value";
 
 import type { PolylineAppearance } from "../../..";
 import { classificationType, shadowMode } from "../../common";
+import { useContext } from "../context";
 import {
   EntityExt,
   toDistanceDisplayCondition,
@@ -34,6 +35,8 @@ export default function Polyline({ id, isVisible, property, geometry, layer, fea
     [geometry?.coordinates, geometry?.type, property?.coordinates],
   );
 
+  const { requestRender } = useContext();
+
   const {
     clampToGround,
     strokeColor,
@@ -53,6 +56,10 @@ export default function Polyline({ id, isVisible, property, geometry, layer, fea
     () => toDistanceDisplayCondition(property?.near, property?.far),
     [property?.near, property?.far],
   );
+
+  useEffect(() => {
+    requestRender?.();
+  });
 
   return !isVisible || !coordinates || !show ? null : (
     <EntityExt


### PR DESCRIPTION
# Overview

In VIEW3.0, marker isn't updated until camera is moved after changing color.
So I fixed to invoke requestRender in primitive features like marker, polyline and polygon whenever the each feature component is updated.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
