### PR TITLE
chore(web): reset current page on tab change

### DIFF
--- a/web/src/beta/components/Popover/index.tsx
+++ b/web/src/beta/components/Popover/index.tsx
@@ -7,6 +7,7 @@ import {
 import * as React from "react";
 
 import { PopoverContext, usePopoverContext } from "@reearth/beta/components/Popover/context";
+import { useTheme } from "@reearth/services/theme";
 
 import usePopover from "./hooks";
 import { PopoverOptions } from "./types";
@@ -72,6 +73,7 @@ export const Content = React.forwardRef<
   React.HTMLProps<HTMLDivElement> & ContentProps
 >(function Content({ style, className, attachToRoot = false, ...props }, propRef) {
   const { context: floatingContext, ...context } = usePopoverContext();
+  const theme = useTheme();
   const ref = useMergeRefs([context.refs.setFloating, propRef]);
   const { isMounted, styles: transitionStyles } = useTransitionStyles(floatingContext, {
     duration: 50,
@@ -87,7 +89,12 @@ export const Content = React.forwardRef<
         <div
           ref={ref}
           className={className}
-          style={{ ...context.floatingStyles, ...transitionStyles, ...style }}
+          style={{
+            ...context.floatingStyles,
+            ...transitionStyles,
+            ...style,
+            zIndex: theme.zIndexes.editor.popover,
+          }}
           {...context.getFloatingProps(props)}>
           {props.children}
         </div>

--- a/web/src/beta/components/fields/SelectField/index.tsx
+++ b/web/src/beta/components/fields/SelectField/index.tsx
@@ -20,6 +20,7 @@ type CommonProps = {
   // Property field
   name?: string;
   description?: string;
+  attachToRoot?: boolean;
 };
 
 export type SingleSelectProps = {
@@ -46,6 +47,7 @@ const SelectField: React.FC<Props> = ({
   disabled = false,
   name,
   description,
+  attachToRoot,
 }) => {
   const t = useT();
 
@@ -110,7 +112,7 @@ const SelectField: React.FC<Props> = ({
               <ArrowIcon icon="arrowDown" open={open} size={12} />
             </InputWrapper>
           </Popover.Trigger>
-          <PickerWrapper attachToRoot>
+          <PickerWrapper attachToRoot={attachToRoot}>
             {options?.map(({ label: value, key }) => (
               <OptionWrapper
                 key={key}

--- a/web/src/beta/components/fields/common/TextInput/index.tsx
+++ b/web/src/beta/components/fields/common/TextInput/index.tsx
@@ -36,9 +36,8 @@ const TextInput: React.FC<Props> = ({
       const newValue = e.currentTarget.value;
       if (newValue === undefined) return;
       setCurrentValue(newValue);
-      onChange?.(newValue);
     },
-    [onChange],
+    [],
   );
 
   const handleBlur = useCallback(() => {

--- a/web/src/beta/features/Editor/DataSourceManager/Common/index.tsx
+++ b/web/src/beta/features/Editor/DataSourceManager/Common/index.tsx
@@ -32,6 +32,7 @@ const SelectDataType: React.FC<{ fileFormat: string; setFileFormat: (k: string) 
       options={["GeoJSON", "KML", "CZML"].map(v => ({ key: v, label: v }))}
       name={t("File Format")}
       description={t("File format of the data source you want to add.")}
+      attachToRoot
       onChange={setFileFormat}
     />
   );

--- a/web/src/beta/features/Editor/index.tsx
+++ b/web/src/beta/features/Editor/index.tsx
@@ -43,6 +43,7 @@ const Editor: React.FC<Props> = ({ sceneId, projectId, workspaceId, tab }) => {
     handleCameraUpdate,
     handlePropertyValueUpdate,
   } = useHooks({ sceneId, tab });
+
   const {
     selectedStory,
     storyPanelRef,
@@ -178,6 +179,11 @@ const Editor: React.FC<Props> = ({ sceneId, projectId, workspaceId, tab }) => {
     handleWidgetEditorToggle,
   });
 
+  const handleTabChange = useCallback(
+    () => storyPanelRef.current?.handleCurrentPageChange(undefined),
+    [storyPanelRef],
+  );
+
   return (
     <DndProvider>
       <Wrapper>
@@ -186,6 +192,7 @@ const Editor: React.FC<Props> = ({ sceneId, projectId, workspaceId, tab }) => {
           projectId={projectId}
           workspaceId={workspaceId}
           currentTab={tab}
+          onTabChange={handleTabChange}
         />
         <MainSection>
           {leftPanel && (

--- a/web/src/beta/features/Navbar/index.tsx
+++ b/web/src/beta/features/Navbar/index.tsx
@@ -11,6 +11,7 @@ type Props = {
   isDashboard?: boolean;
   currentTab?: Tab;
   page?: "editor" | "settings";
+  onTabChange?: () => void;
 };
 
 export const Tabs = ["map", "story", "widgets", "publish"] as const;
@@ -29,6 +30,7 @@ const Navbar: React.FC<Props> = ({
   currentTab = "map",
   isDashboard = false,
   page = "editor",
+  onTabChange,
 }) => {
   const {
     currentProject,
@@ -48,6 +50,7 @@ const Navbar: React.FC<Props> = ({
     currentTab,
     sceneId,
     page,
+    onTabChange,
   });
 
   return (

--- a/web/src/beta/features/Navbar/useRightSection.tsx
+++ b/web/src/beta/features/Navbar/useRightSection.tsx
@@ -11,11 +11,12 @@ type Props = {
   currentTab?: Tab;
   sceneId?: string;
   page: "editor" | "settings";
+  onTabChange?: () => void;
 };
 
-const useRightSide = ({ currentTab, page, sceneId }: Props) => {
+const useRightSide = ({ currentTab, page, sceneId, onTabChange }: Props) => {
   const t = useT();
-  const handleEditorNavigation = useEditorNavigation({ sceneId });
+  const handleEditorNavigation = useEditorNavigation({ sceneId, onTabChange });
 
   const rightSide = useMemo(() => {
     if (page === "editor") {

--- a/web/src/beta/hooks/navigationHooks.ts
+++ b/web/src/beta/hooks/navigationHooks.ts
@@ -3,14 +3,22 @@ import { useNavigate } from "react-router-dom";
 
 import { Tab } from "@reearth/beta/features/Navbar";
 
-export const useEditorNavigation = ({ sceneId }: { sceneId?: string }) => {
+export const useEditorNavigation = ({
+  sceneId,
+  onTabChange,
+}: {
+  sceneId?: string;
+  onTabChange?: () => void;
+}) => {
   const navigate = useNavigate();
 
   const handleNavigate = useCallback(
     (tab: Tab) => {
+      if (!sceneId) return;
+      onTabChange?.();
       navigate(`/scene/${sceneId}/${tab}`);
     },
-    [sceneId, navigate],
+    [sceneId, onTabChange, navigate],
   );
 
   return sceneId ? handleNavigate : undefined;
@@ -21,6 +29,7 @@ export const useSettingsNavigation = ({ projectId }: { projectId?: string }) => 
 
   const handleNavigate = useCallback(
     (page?: "public" | "story" | "asset" | "plugin") => {
+      if (!projectId || !page) return;
       navigate(`/settings/project/${projectId}/${page}`);
     },
     [projectId, navigate],

--- a/web/src/beta/lib/core/StoryPanel/ActionPanel/index.tsx
+++ b/web/src/beta/lib/core/StoryPanel/ActionPanel/index.tsx
@@ -122,7 +122,7 @@ const ActionPanel: React.FC<Props> = ({
               ),
           )}
         </BlockOptions>
-        <StyledPopoverContent>
+        <StyledPopoverContent attachToRoot>
           {showPadding ? (
             <SettingsDropdown>
               <SettingsHeading>

--- a/web/src/beta/lib/core/StoryPanel/Page/index.tsx
+++ b/web/src/beta/lib/core/StoryPanel/Page/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from "react";
+import { Fragment, MutableRefObject, useEffect } from "react";
 
 import DragAndDropList from "@reearth/beta/components/DragAndDropList";
 import type { Spacing, ValueType, ValueTypes } from "@reearth/beta/utils/value";
@@ -7,6 +7,8 @@ import { useT } from "@reearth/services/i18n";
 import { styled } from "@reearth/services/theme";
 
 import StoryBlock from "../Block";
+import { STORY_PANEL_CONTENT_ELEMENT_ID } from "../constants";
+import { useElementOnScreen } from "../hooks/useElementOnScreen";
 import SelectableArea from "../SelectableArea";
 
 import BlockAddBar from "./BlockAddBar";
@@ -19,6 +21,9 @@ type Props = {
   selectedStoryBlockId?: string;
   showPageSettings?: boolean;
   isEditable?: boolean;
+  isAutoScrolling?: MutableRefObject<boolean>;
+  scrollTimeoutRef: MutableRefObject<NodeJS.Timeout | undefined>;
+  onCurrentPageChange?: (pageId: string, disableScrollIntoView?: boolean) => void;
   onPageSettingsToggle?: () => void;
   onPageSelect?: (pageId?: string | undefined) => void;
   onBlockCreate?: (
@@ -58,6 +63,9 @@ const StoryPanel: React.FC<Props> = ({
   selectedStoryBlockId,
   showPageSettings,
   isEditable,
+  scrollTimeoutRef,
+  isAutoScrolling,
+  onCurrentPageChange,
   onPageSettingsToggle,
   onPageSelect,
   onBlockCreate,
@@ -87,6 +95,31 @@ const StoryPanel: React.FC<Props> = ({
     onBlockCreate,
   });
 
+  const { containerRef, isIntersecting } = useElementOnScreen({
+    root: document.getElementById(STORY_PANEL_CONTENT_ELEMENT_ID),
+    threshold: 0.2,
+  });
+
+  useEffect(() => {
+    if (isIntersecting) {
+      const id = containerRef.current?.id;
+      if (id) {
+        if (isAutoScrolling?.current) {
+          const wrapperElement = document.getElementById(STORY_PANEL_CONTENT_ELEMENT_ID);
+
+          wrapperElement?.addEventListener("scroll", () => {
+            clearTimeout(scrollTimeoutRef.current);
+            scrollTimeoutRef.current = setTimeout(function () {
+              isAutoScrolling.current = false;
+            }, 100);
+          });
+        } else {
+          onCurrentPageChange?.(id, true);
+        }
+      }
+    }
+  }, [isIntersecting, containerRef, isAutoScrolling, scrollTimeoutRef, onCurrentPageChange]);
+
   return (
     <SelectableArea
       title={page?.title ?? t("Page")}
@@ -100,7 +133,11 @@ const StoryPanel: React.FC<Props> = ({
       isEditable={isEditable}
       onClick={() => onPageSelect?.(page?.id)}
       onSettingsToggle={onPageSettingsToggle}>
-      <Wrapper id={page?.id} padding={panelSettings.padding.value} gap={panelSettings.gap.value}>
+      <Wrapper
+        id={page?.id}
+        ref={containerRef}
+        padding={panelSettings.padding.value}
+        gap={panelSettings.gap.value}>
         {(isEditable || title?.title?.value) && (
           <StoryBlock
             block={{

--- a/web/src/beta/lib/core/StoryPanel/PanelContent/hooks.ts
+++ b/web/src/beta/lib/core/StoryPanel/PanelContent/hooks.ts
@@ -1,22 +1,14 @@
-import { MutableRefObject, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { STORY_PANEL_CONTENT_ELEMENT_ID } from "../constants";
-import type { StoryPage } from "../hooks";
 
 export type { StoryPage } from "../hooks";
 export { STORY_PANEL_CONTENT_ELEMENT_ID } from "../constants";
 
 export default ({
-  pages,
-  currentPageId,
-  isAutoScrolling,
   onBlockCreate,
   onBlockDelete,
-  onCurrentPageChange,
 }: {
-  pages?: StoryPage[];
-  currentPageId?: string;
-  isAutoScrolling?: MutableRefObject<boolean>;
   onBlockCreate?: (
     pageId?: string | undefined,
     extensionId?: string | undefined,
@@ -24,9 +16,7 @@ export default ({
     index?: number | undefined,
   ) => Promise<void>;
   onBlockDelete?: (pageId?: string | undefined, blockId?: string | undefined) => Promise<void>;
-  onCurrentPageChange?: (pageId: string, disableScrollIntoView?: boolean) => void;
 }) => {
-  const scrollRef = useRef<number | undefined>(undefined);
   const scrollTimeoutRef = useRef<NodeJS.Timeout>();
 
   const [pageGap, setPageGap] = useState<number>();
@@ -61,69 +51,9 @@ export default ({
     return () => window.removeEventListener("resize", resizeCallback);
   }, []);
 
-  useEffect(() => {
-    const ids = pages?.map(p => p.id) as string[];
-    const panelContentElement = document.getElementById(STORY_PANEL_CONTENT_ELEMENT_ID);
-
-    const observer = new IntersectionObserver(
-      entries => {
-        // to avoid conflicts with page selection in core's parent
-        if (isAutoScrolling?.current) {
-          const wrapperElement = document.getElementById(STORY_PANEL_CONTENT_ELEMENT_ID);
-
-          wrapperElement?.addEventListener("scroll", () => {
-            clearTimeout(scrollTimeoutRef.current);
-            scrollTimeoutRef.current = setTimeout(function () {
-              isAutoScrolling.current = false;
-            }, 100);
-          });
-
-          return;
-        }
-
-        entries.forEach(entry => {
-          const id = entry.target.getAttribute("id") ?? "";
-          if (!id ?? currentPageId === id) return;
-
-          const diff = (scrollRef.current as number) - (panelContentElement?.scrollTop as number);
-          const isScrollingUp = diff > 0;
-
-          if (entry.isIntersecting) {
-            onCurrentPageChange?.(id, true);
-            scrollRef.current = panelContentElement?.scrollTop;
-            return;
-          }
-          const currentIndex = ids?.indexOf(id) as number;
-          const prevEntry = ids[currentIndex - 1];
-          if (isScrollingUp) {
-            const id = prevEntry;
-            onCurrentPageChange?.(id, true);
-          }
-        });
-      },
-      {
-        root: panelContentElement,
-        threshold: 0.2,
-      },
-    );
-    ids?.forEach(id => {
-      const e = document.getElementById(id);
-      if (e) {
-        observer.observe(e);
-      }
-    });
-    return () => {
-      ids?.forEach(id => {
-        const e = document.getElementById(id);
-        if (e) {
-          observer.unobserve(e);
-        }
-      });
-    };
-  }, [pages, currentPageId, isAutoScrolling, onCurrentPageChange]);
-
   return {
     pageGap,
+    scrollTimeoutRef,
     handleBlockCreate,
     handleBlockDelete,
   };

--- a/web/src/beta/lib/core/StoryPanel/PanelContent/index.tsx
+++ b/web/src/beta/lib/core/StoryPanel/PanelContent/index.tsx
@@ -10,7 +10,6 @@ import useHooks, { STORY_PANEL_CONTENT_ELEMENT_ID, type StoryPage as StoryPageTy
 
 export type Props = {
   pages?: StoryPageType[];
-  currentPageId?: string;
   selectedPageId?: string;
   installableStoryBlocks?: InstallableStoryBlock[];
   selectedStoryBlockId?: string;
@@ -54,7 +53,6 @@ export type Props = {
 
 const StoryContent: React.FC<Props> = ({
   pages,
-  currentPageId,
   selectedPageId,
   installableStoryBlocks,
   selectedStoryBlockId,
@@ -74,13 +72,9 @@ const StoryContent: React.FC<Props> = ({
   onPropertyItemMove,
   onPropertyItemDelete,
 }) => {
-  const { pageGap, handleBlockCreate, handleBlockDelete } = useHooks({
-    pages,
-    currentPageId,
-    isAutoScrolling,
+  const { pageGap, scrollTimeoutRef, handleBlockCreate, handleBlockDelete } = useHooks({
     onBlockCreate,
     onBlockDelete,
-    onCurrentPageChange,
   });
 
   return (
@@ -97,6 +91,9 @@ const StoryContent: React.FC<Props> = ({
             selectedStoryBlockId={selectedStoryBlockId}
             showPageSettings={showPageSettings}
             isEditable={isEditable}
+            scrollTimeoutRef={scrollTimeoutRef}
+            isAutoScrolling={isAutoScrolling}
+            onCurrentPageChange={onCurrentPageChange}
             onPageSettingsToggle={onPageSettingsToggle}
             onPageSelect={onPageSelect}
             onBlockCreate={handleBlockCreate(p.id)}

--- a/web/src/beta/lib/core/StoryPanel/hooks.ts
+++ b/web/src/beta/lib/core/StoryPanel/hooks.ts
@@ -101,15 +101,16 @@ export default (
 
       if (!pageId) {
         const element = document.getElementById(STORY_PANEL_CONTENT_ELEMENT_ID);
-        if (element) element.scrollTo(0, 0);
+        if (element) element.scrollTo(0, 0); // If no pageId, newPage will be the first page and we scroll all the way to the top here
       } else if (!disableScrollIntoView) {
         const element = document.getElementById(newPage.id);
         isAutoScrolling.current = true;
         element?.scrollIntoView({ behavior: "smooth" });
       }
-      handlePageTime(newPage);
-      const cameraAnimation = newPage.property?.cameraAnimation;
 
+      handlePageTime(newPage);
+
+      const cameraAnimation = newPage.property?.cameraAnimation;
       const destination = cameraAnimation?.cameraPosition?.value;
       if (!destination) return;
 
@@ -143,18 +144,19 @@ export default (
 
   // Update what layers will be shown in the Visualizer on page change.
   useEffect(() => {
+    const vizRef = visualizer?.current;
+    const currentLayerIds = vizRef?.layers.layers()?.map(l => l.id);
+
     const currentPage = getPage(currentPageId, selectedStory?.pages);
     if (currentPage) {
-      const currentLayerIds = visualizer.current?.layers.layers()?.map(l => l.id);
       if (currentLayerIds) {
-        visualizer.current?.layers.show(
-          ...currentLayerIds.filter(id => currentPage.layerIds?.includes(id)),
-        );
-        visualizer.current?.layers.hide(
-          ...currentLayerIds.filter(id => !currentPage.layerIds?.includes(id)),
-        );
+        vizRef?.layers.show(...currentLayerIds.filter(id => currentPage.layerIds?.includes(id)));
+        vizRef?.layers.hide(...currentLayerIds.filter(id => !currentPage.layerIds?.includes(id)));
       }
     }
+    return () => {
+      if (currentLayerIds) vizRef?.layers.show(...currentLayerIds);
+    };
   }, [currentPageId, selectedStory?.pages, visualizer]);
 
   return {

--- a/web/src/beta/lib/core/StoryPanel/hooks.ts
+++ b/web/src/beta/lib/core/StoryPanel/hooks.ts
@@ -4,13 +4,13 @@ import type { Story, StoryPage } from "@reearth/beta/lib/core/StoryPanel/types";
 
 import { useVisualizer } from "../Visualizer";
 
-import { DEFAULT_STORY_PAGE_DURATION } from "./constants";
+import { DEFAULT_STORY_PAGE_DURATION, STORY_PANEL_CONTENT_ELEMENT_ID } from "./constants";
 
 export type { Story, StoryPage } from "@reearth/beta/lib/core/StoryPanel/types";
 
 export type StoryPanelRef = {
   currentPageId?: string;
-  handleCurrentPageChange: (pageId: string, disableScrollIntoView?: boolean) => void;
+  handleCurrentPageChange: (pageId?: string, disableScrollIntoView?: boolean) => void;
 };
 
 export default (
@@ -21,7 +21,7 @@ export default (
   }: {
     selectedStory?: Story;
     isEditable?: boolean;
-    onCurrentPageChange?: (id: string, disableScrollIntoView?: boolean) => void;
+    onCurrentPageChange?: (id?: string, disableScrollIntoView?: boolean) => void;
   },
   ref: Ref<StoryPanelRef>,
 ) => {
@@ -90,16 +90,19 @@ export default (
   );
 
   const handleCurrentPageChange = useCallback(
-    (pageId: string, disableScrollIntoView?: boolean) => {
+    (pageId?: string, disableScrollIntoView?: boolean) => {
       if (pageId === currentPageId) return;
 
       const newPage = getPage(pageId, selectedStory?.pages);
       if (!newPage) return;
 
-      onCurrentPageChange?.(pageId);
-      setCurrentPageId(pageId);
+      onCurrentPageChange?.(newPage.id);
+      setCurrentPageId(newPage.id);
 
-      if (!disableScrollIntoView) {
+      if (!pageId) {
+        const element = document.getElementById(STORY_PANEL_CONTENT_ELEMENT_ID);
+        if (element) element.scrollTo(0, 0);
+      } else if (!disableScrollIntoView) {
         const element = document.getElementById(newPage.id);
         isAutoScrolling.current = true;
         element?.scrollIntoView({ behavior: "smooth" });
@@ -169,6 +172,7 @@ export default (
 };
 
 const getPage = (id?: string, pages?: StoryPage[]) => {
-  if (!id || !pages || !pages.length) return;
+  if (!pages?.length) return;
+  if (!id) return pages[0]; // If no ID, set first page
   return pages.find(p => p.id === id);
 };

--- a/web/src/beta/lib/core/StoryPanel/hooks.ts
+++ b/web/src/beta/lib/core/StoryPanel/hooks.ts
@@ -4,7 +4,7 @@ import type { Story, StoryPage } from "@reearth/beta/lib/core/StoryPanel/types";
 
 import { useVisualizer } from "../Visualizer";
 
-import { DEFAULT_STORY_PAGE_DURATION } from "./constants";
+import { DEFAULT_STORY_PAGE_DURATION, STORY_PANEL_CONTENT_ELEMENT_ID } from "./constants";
 
 export type { Story, StoryPage } from "@reearth/beta/lib/core/StoryPanel/types";
 
@@ -99,7 +99,10 @@ export default (
       onCurrentPageChange?.(newPage.id);
       setCurrentPageId(newPage.id);
 
-      if (!disableScrollIntoView) {
+      if (!pageId) {
+        const element = document.getElementById(STORY_PANEL_CONTENT_ELEMENT_ID);
+        if (element) element.scrollTo(0, 0);
+      } else if (!disableScrollIntoView) {
         const element = document.getElementById(newPage.id);
         isAutoScrolling.current = true;
         element?.scrollIntoView({ behavior: "smooth" });

--- a/web/src/beta/lib/core/StoryPanel/hooks.ts
+++ b/web/src/beta/lib/core/StoryPanel/hooks.ts
@@ -4,7 +4,7 @@ import type { Story, StoryPage } from "@reearth/beta/lib/core/StoryPanel/types";
 
 import { useVisualizer } from "../Visualizer";
 
-import { DEFAULT_STORY_PAGE_DURATION, STORY_PANEL_CONTENT_ELEMENT_ID } from "./constants";
+import { DEFAULT_STORY_PAGE_DURATION } from "./constants";
 
 export type { Story, StoryPage } from "@reearth/beta/lib/core/StoryPanel/types";
 
@@ -99,10 +99,7 @@ export default (
       onCurrentPageChange?.(newPage.id);
       setCurrentPageId(newPage.id);
 
-      if (!pageId) {
-        const element = document.getElementById(STORY_PANEL_CONTENT_ELEMENT_ID);
-        if (element) element.scrollTo(0, 0);
-      } else if (!disableScrollIntoView) {
+      if (!disableScrollIntoView) {
         const element = document.getElementById(newPage.id);
         isAutoScrolling.current = true;
         element?.scrollIntoView({ behavior: "smooth" });
@@ -159,7 +156,6 @@ export default (
 
   return {
     pageInfo,
-    currentPageId,
     selectedPageId,
     selectedBlockId,
     showPageSettings,

--- a/web/src/beta/lib/core/StoryPanel/hooks/useElementOnScreen.tsx
+++ b/web/src/beta/lib/core/StoryPanel/hooks/useElementOnScreen.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useRef, useState } from "react";
+
+export const useElementOnScreen = (options: IntersectionObserverInit) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isIntersecting, setIsIntersecting] = useState(false);
+
+  useEffect(() => {
+    const elementRef = containerRef.current;
+    const observer = new IntersectionObserver(entries => {
+      const [entry] = entries;
+      setIsIntersecting(entry.isIntersecting);
+    }, options);
+
+    if (elementRef) observer.observe(elementRef);
+
+    return () => {
+      if (elementRef) observer.unobserve(elementRef);
+    };
+  }, [options]);
+
+  return { containerRef, isIntersecting };
+};

--- a/web/src/beta/lib/core/StoryPanel/index.tsx
+++ b/web/src/beta/lib/core/StoryPanel/index.tsx
@@ -24,7 +24,7 @@ export type StoryPanelProps = {
   selectedStory?: Story;
   isEditable?: boolean;
   installableBlocks?: InstallableStoryBlock[];
-  onCurrentPageChange?: (id: string, disableScrollIntoView?: boolean) => void;
+  onCurrentPageChange?: (id?: string, disableScrollIntoView?: boolean) => void;
   onBlockCreate?: (
     pageId?: string | undefined,
     extensionId?: string | undefined,

--- a/web/src/beta/lib/core/StoryPanel/index.tsx
+++ b/web/src/beta/lib/core/StoryPanel/index.tsx
@@ -75,7 +75,6 @@ export const StoryPanel = memo(
     ) => {
       const {
         pageInfo,
-        currentPageId,
         selectedPageId,
         selectedBlockId,
         showPageSettings,
@@ -103,7 +102,6 @@ export const StoryPanel = memo(
           )}
           <StoryContent
             pages={selectedStory?.pages}
-            currentPageId={currentPageId}
             selectedPageId={selectedPageId}
             installableStoryBlocks={installableBlocks}
             selectedStoryBlockId={selectedBlockId}


### PR DESCRIPTION
# Overview
Until now, even if you change tabs (from publish to story, or vice versa), the currently scrolled position of the StoryPanel remained. Instead of this, its more desirable to reset the storypanel.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
