### PR TITLE
fix(web): core marker extrude check for coordinates height

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/Feature/Marker/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Marker/index.tsx
@@ -78,7 +78,7 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
   }, [coordinates]);
 
   const extrudePoints = useMemo(() => {
-    return extrude && coordinates && typeof coordinates[3] === "number"
+    return extrude && coordinates && typeof coordinates[2] === "number"
       ? [
           Cartesian3.fromDegrees(coordinates[0], coordinates[1], coordinates[2]),
           Cartesian3.fromDegrees(coordinates[0], coordinates[1], 0),

--- a/web/src/classic/core/engines/Cesium/Feature/Marker/index.tsx
+++ b/web/src/classic/core/engines/Cesium/Feature/Marker/index.tsx
@@ -73,7 +73,7 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
   }, [coordinates]);
 
   const extrudePoints = useMemo(() => {
-    return extrude && coordinates && typeof coordinates[3] === "number"
+    return extrude && coordinates && typeof coordinates[2] === "number"
       ? [
           Cartesian3.fromDegrees(coordinates[0], coordinates[1], coordinates[2]),
           Cartesian3.fromDegrees(coordinates[0], coordinates[1], 0),


### PR DESCRIPTION
# Overview

This PR fixs the check for coordinates height of marker extrudePoints in both classic core and beta core.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
