### PR TITLE
chore(web): stringify label text

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/Feature/Marker/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Marker/index.tsx
@@ -137,6 +137,8 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
     [property?.near, property?.far],
   );
 
+  const stringLabelText = useMemo(() => String(labelText), [labelText]);
+
   useEffect(() => {
     requestRender?.();
   });
@@ -205,7 +207,7 @@ export default function Marker({ property, id, isVisible, geometry, layer, featu
             pixelOffset={pixelOffset}
             fillColor={labelColorCesium}
             font={toCSSFont(labelTypography, { fontSize: 30 })}
-            text={labelText}
+            text={stringLabelText}
             showBackground={labelBackground}
             backgroundColor={labelBackgroundColorCesium}
             backgroundPadding={labelBackgroundPadding}


### PR DESCRIPTION
# Overview

When use expression to set label text we get values from feature property and the value could be number.
When pass number to `LabelGraphics` text, cesium will throw out error.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
