### PR TITLE
chore(web): add frustum model

### DIFF
--- a/web/src/beta/lib/core/Crust/index.tsx
+++ b/web/src/beta/lib/core/Crust/index.tsx
@@ -34,6 +34,8 @@ export type { ValueTypes, ValueType, InteractionModeType } from "./types";
 export type { Block } from "./Infobox";
 
 export type { ExternalPluginProps } from "./Plugins";
+export { INTERACTION_MODES } from "./interactionMode";
+export { FEATURE_FLAGS } from "./featureFlags";
 
 export type {
   Context,

--- a/web/src/beta/lib/core/Map/Layers/hooks.ts
+++ b/web/src/beta/lib/core/Map/Layers/hooks.ts
@@ -428,6 +428,7 @@ export default function useHooks({
         );
         return newLayers;
       });
+      setOverridenLayers(layers => layers.filter(l => !ids.includes(l.id)));
     },
     [layerMap, atomMap, lazyLayerMap, initialSelectedLayer, showLayer, select],
   );

--- a/web/src/beta/lib/core/Map/index.tsx
+++ b/web/src/beta/lib/core/Map/index.tsx
@@ -1,12 +1,13 @@
 import { forwardRef, useMemo, type Ref } from "react";
 
+import { INTERACTION_MODES } from "../Crust";
+
 import useHooks, { MapRef } from "./hooks";
 import Layers, { type Props as LayersProps } from "./Layers";
 import type { Engine, EngineProps } from "./types";
 
 export * from "./types";
 export { useGet, type WrappedRef, type Undefinable, useOverriddenProperty } from "./utils";
-export { FEATURE_FLAGS } from "../Crust/featureFlags";
 
 export type {
   NaiveLayer,
@@ -46,6 +47,7 @@ function Map(
     timelineManagerRef,
     sceneProperty,
     onLayerSelect,
+    featureFlags = INTERACTION_MODES.default,
     ...props
   }: Props,
   ref: Ref<MapRef>,
@@ -87,6 +89,7 @@ function Map(
       requestingRenderMode={requestingRenderMode}
       timelineManagerRef={timelineManagerRef}
       onLayerSelect={handleEngineLayerSelect}
+      featureFlags={featureFlags}
       {...props}>
       <Layers
         ref={layersRef}

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Frustum/FrustumColorAppearance.ts
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Frustum/FrustumColorAppearance.ts
@@ -1,0 +1,38 @@
+// Ref: https://github.com/takram-design-engineering/plateau-view/blob/main/libs/pedestrian/src/FrustumAppearance.ts
+
+import { Color, Material, PerInstanceColorAppearance, VertexFormat } from "cesium";
+
+import fragmentShaderSource from "./shaders/frustumAppearance.frag.glsl?raw";
+import vertexShaderSource from "./shaders/frustumAppearance.vert.glsl?raw";
+
+export class FrustumColorAppearance extends PerInstanceColorAppearance {
+  constructor({ color = Color.WHITE, opacity = 1 }: { color?: Color; opacity?: number }) {
+    super({
+      fragmentShaderSource,
+      vertexShaderSource,
+      translucent: true,
+    });
+
+    this.material = new Material({
+      fabric: {
+        uniforms: {
+          color,
+          opacity,
+        },
+        components: {
+          diffuse: "color.rgb",
+          alpha: "opacity",
+        },
+      },
+    });
+  }
+
+  static VERTEX_FORMAT = new VertexFormat({
+    position: true,
+    normal: true,
+    st: true,
+    tangent: true,
+    bitangent: true,
+    color: true,
+  });
+}

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Frustum/getFieldOfView.ts
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Frustum/getFieldOfView.ts
@@ -1,0 +1,23 @@
+import { Cartesian2, PerspectiveFrustum, type Camera } from "@cesium/engine";
+import invariant from "tiny-invariant";
+
+const cartesianScratch = new Cartesian2();
+
+export function getFieldOfView(camera: Camera, zoom: number): number {
+  const fov = getFieldOfViewSeparate(camera, zoom, cartesianScratch);
+  const frustum = camera.frustum;
+  invariant(frustum instanceof PerspectiveFrustum);
+  return frustum.aspectRatio > 1 ? fov.x : fov.y;
+}
+
+export function getFieldOfViewSeparate(
+  camera: Camera,
+  zoom: number,
+  result = new Cartesian2(),
+): Cartesian2 {
+  const frustum = camera.frustum;
+  invariant(frustum instanceof PerspectiveFrustum);
+  result.x = Math.atan(Math.pow(2, 1 - zoom)) * 2;
+  result.y = 2 * Math.atan(frustum.aspectRatio * Math.tan(result.x / 2));
+  return result;
+}

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Frustum/index.stories.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Frustum/index.stories.tsx
@@ -1,0 +1,49 @@
+import { Meta, Story } from "@storybook/react";
+
+import { engine } from "../..";
+import Component, { Props } from "../../../../Map";
+
+export default {
+  component: Component,
+  parameters: { actions: { argTypesRegex: "^on.*" } },
+} as Meta;
+
+const Template: Story<Props> = args => <Component {...args} />;
+
+export const Default = Template.bind([]);
+Default.args = {
+  engine: "cesium",
+  engines: {
+    cesium: engine,
+  },
+  ready: true,
+  layers: [
+    {
+      id: "l",
+      type: "simple",
+      data: {
+        type: "geojson",
+        value: {
+          type: "Feature",
+          geometry: {
+            type: "Point",
+            coordinates: [0, 0, 1000],
+          },
+        },
+      },
+      frustum: {
+        zoom: 1,
+        color: "#ffffff",
+        length: 10000,
+      },
+    },
+  ],
+  property: {
+    tiles: [
+      {
+        id: "default",
+        tile_type: "default",
+      },
+    ],
+  },
+};

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Frustum/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Frustum/index.tsx
@@ -1,0 +1,163 @@
+// Ref: https://github.com/takram-design-engineering/plateau-view/blob/main/libs/pedestrian/src/StreetViewFrustum.tsx
+
+import {
+  Cartesian3,
+  Math as CesiumMath,
+  FrustumGeometry,
+  PerspectiveFrustum,
+  Quaternion,
+  GeometryInstance,
+  ComponentDatatype,
+  GeometryAttribute,
+  Primitive as CesiumPrimitive,
+  HeadingPitchRoll,
+  Transforms,
+  Cartesian2,
+  Matrix4,
+} from "cesium";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { CesiumComponentRef, Primitive, useCesium } from "resium";
+
+import { FrustumAppearance } from "@reearth/beta/lib/core/mantle";
+import { toColor } from "@reearth/beta/utils/value";
+
+import { usePreRender } from "../../hooks/useSceneEvent";
+import { useContext } from "../context";
+import { attachTag, type FeatureComponentConfig, type FeatureProps } from "../utils";
+
+import { FrustumColorAppearance } from "./FrustumColorAppearance";
+import { getFieldOfViewSeparate } from "./getFieldOfView";
+
+export type Props = FeatureProps<Property>;
+
+export type Property = FrustumAppearance;
+
+const colorGeometryAttribute = new GeometryAttribute({
+  componentDatatype: ComponentDatatype.UNSIGNED_BYTE,
+  componentsPerAttribute: 3,
+  normalize: true,
+  values: new Uint8Array(
+    // Colors of vertices adjacent to the near plane are 255. 0 otherwise.
+    [
+      0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0, 0xff, 0xff, 0, 0xff, 0, 0, 0xff,
+      0xff, 0, 0, 0xff,
+    ].flatMap(value => [value, value, value]),
+  ),
+});
+
+const scaleScratch = new Cartesian3();
+const fovScratch = new Cartesian2();
+
+const TAN_PI_OVER_FOUR = Math.tan(CesiumMath.PI_OVER_FOUR);
+
+export default function Frustum({ isVisible, property, geometry, layer, feature }: Props) {
+  const { viewer } = useCesium();
+  const {
+    color,
+    show = true,
+    opacity = 1,
+    zoom = 1,
+    aspectRatio = 3 / 2,
+    length = 200,
+  } = property || {};
+  const { requestRender } = useContext();
+  const primitiveRef = useRef<CesiumComponentRef<CesiumPrimitive>>(null);
+
+  const { translate, rotate } = layer?.transition ?? {};
+  const translatedCoords = useMemo(
+    () => (translate ? Cartesian3.fromDegrees(...translate) : undefined),
+    [translate],
+  );
+
+  const coordinates = useMemo(
+    () => (geometry?.type === "Point" ? geometry.coordinates : undefined),
+    [geometry?.coordinates, geometry?.type],
+  );
+  const position = useMemo(() => {
+    return coordinates
+      ? Cartesian3.fromDegrees(coordinates[0], coordinates[1], coordinates[2])
+      : Cartesian3.ZERO;
+  }, [coordinates]);
+
+  const geometryInstance = useMemo(() => {
+    const geometry = FrustumGeometry.createGeometry(
+      new FrustumGeometry({
+        frustum: new PerspectiveFrustum({
+          fov: CesiumMath.PI_OVER_TWO,
+          aspectRatio: 1,
+          near: 0.0001,
+          far: 1,
+        }),
+        origin: Cartesian3.ZERO,
+        orientation: Quaternion.IDENTITY,
+        vertexFormat: FrustumColorAppearance.VERTEX_FORMAT,
+      }),
+    );
+
+    if (!geometry) return;
+
+    geometry.attributes.color = colorGeometryAttribute;
+    return new GeometryInstance({ geometry });
+  }, []);
+
+  const appearance = useMemo(
+    () =>
+      new FrustumColorAppearance({
+        color: toColor(color),
+      }),
+    [color],
+  );
+
+  useEffect(() => {
+    requestRender?.();
+  });
+
+  useLayoutEffect(() => {
+    if (!primitiveRef.current || primitiveRef.current.cesiumElement?.isDestroyed()) return;
+    attachTag(primitiveRef.current.cesiumElement, {
+      layerId: layer?.id,
+      featureId: feature?.id,
+    });
+  }, [layer?.id, feature?.id]);
+
+  usePreRender(() => {
+    const primitive = primitiveRef.current?.cesiumElement;
+    if (!primitive || primitive.isDestroyed() || !viewer) return;
+
+    primitive.appearance.material.uniforms.opacity = opacity;
+
+    const origin = translatedCoords ?? position;
+    const rotation = Transforms.headingPitchRollQuaternion(
+      origin,
+      new HeadingPitchRoll(
+        CesiumMath.toRadians(rotate?.[0] ?? 0) + CesiumMath.PI_OVER_TWO,
+        CesiumMath.PI_OVER_TWO - CesiumMath.toRadians(rotate?.[1] ?? 0),
+        CesiumMath.toRadians(rotate?.[2] ?? 0),
+      ),
+    );
+    const fov = getFieldOfViewSeparate(viewer.scene.camera, zoom, fovScratch);
+    const farWidth = (Math.tan(fov.x / 2) / TAN_PI_OVER_FOUR) * length;
+    scaleScratch.x = (opacity * farWidth) / aspectRatio;
+    scaleScratch.y = opacity * farWidth;
+    scaleScratch.z = opacity * length;
+    Matrix4.fromTranslationQuaternionRotationScale(
+      origin,
+      rotation,
+      scaleScratch,
+      primitive.modelMatrix,
+    );
+  });
+
+  return !feature || !isVisible || !show ? null : (
+    <Primitive
+      ref={primitiveRef}
+      geometryInstances={geometryInstance}
+      asynchronous={false}
+      appearance={appearance}
+    />
+  );
+}
+
+export const config: FeatureComponentConfig = {
+  noLayer: true,
+};

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Frustum/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Frustum/index.tsx
@@ -109,6 +109,7 @@ export default function Frustum({ isVisible, property, geometry, layer, feature 
   );
 
   useEffect(() => {
+    if (!primitiveRef.current || primitiveRef.current.cesiumElement?.isDestroyed()) return;
     requestRender?.();
   });
 

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Frustum/shaders/frustumAppearance.frag.glsl
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Frustum/shaders/frustumAppearance.frag.glsl
@@ -1,0 +1,31 @@
+in vec3 v_positionEC;
+in vec3 v_normalEC;
+in vec3 v_tangentEC;
+in vec3 v_bitangentEC;
+in vec2 v_st;
+in vec4 v_color;
+
+void main() {
+  vec3 positionToEyeEC = -v_positionEC;
+  mat3 tangentToEyeMatrix = czm_tangentToEyeSpaceMatrix(
+    v_normalEC,
+    v_tangentEC,
+    v_bitangentEC
+  );
+  vec3 normalEC = normalize(v_normalEC);
+
+  // TODO: Make volumetric.
+  czm_materialInput materialInput;
+  materialInput.normalEC = normalEC;
+  materialInput.tangentToEyeMatrix = tangentToEyeMatrix;
+  materialInput.positionToEyeEC = positionToEyeEC;
+  materialInput.st = v_st;
+  czm_material material = czm_getMaterial(materialInput);
+  material.alpha *= v_color.r;
+
+  out_FragColor = czm_phong(
+    normalize(positionToEyeEC),
+    material,
+    czm_lightDirectionEC
+  );
+}

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Frustum/shaders/frustumAppearance.vert.glsl
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Frustum/shaders/frustumAppearance.vert.glsl
@@ -1,0 +1,29 @@
+in vec3 position3DHigh;
+in vec3 position3DLow;
+in vec3 normal;
+in vec3 normal;
+in vec3 tangent;
+in vec3 bitangent;
+in vec2 st;
+in vec4 color;
+in float batchId;
+
+out vec3 v_positionEC;
+out vec3 v_normalEC;
+out vec3 v_tangentEC;
+out vec3 v_bitangentEC;
+out vec2 v_st;
+out vec4 v_color;
+
+void main() {
+  vec4 p = czm_computePosition();
+
+  v_positionEC = (czm_modelViewRelativeToEye * p).xyz;
+  v_normalEC = czm_normal * normal;
+  v_tangentEC = czm_normal * tangent;
+  v_bitangentEC = czm_normal * bitangent;
+  v_st = st;
+  v_color = color;
+
+  gl_Position = czm_modelViewProjectionRelativeToEye * p;
+}

--- a/web/src/beta/lib/core/engines/Cesium/Feature/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/index.tsx
@@ -7,6 +7,7 @@ import type { AppearanceTypes, FeatureComponentProps, ComputedLayer } from "../.
 
 import Box, { config as boxConfig } from "./Box";
 import Ellipsoid, { config as ellipsoidConfig } from "./Ellipsoid";
+import Frustum, { config as frustumConfig } from "./Frustum";
 import Marker, { config as markerConfig } from "./Marker";
 import Model, { config as modelConfig } from "./Model";
 import PhotoOverlay, { config as photoOverlayConfig } from "./PhotoOverlay";
@@ -46,6 +47,7 @@ const components: Record<
   photooverlay: [PhotoOverlay, photoOverlayConfig],
   resource: [Resource, resourceConfig],
   raster: [Raster, rasterConfig],
+  frustum: [Frustum, frustumConfig],
 };
 
 // This indicates what component should render for file extension.

--- a/web/src/beta/lib/core/engines/Cesium/Feature/utils.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/utils.tsx
@@ -13,6 +13,7 @@ import {
   Model,
   Cesium3DTilePointFeature,
   ImageryLayer,
+  Primitive,
 } from "cesium";
 import md5 from "js-md5";
 import { pick } from "lodash-es";
@@ -100,6 +101,7 @@ export function attachTag(
     | Cesium3DTileset
     | InternalCesium3DTileFeature
     | ImageryLayer
+    | Primitive
     | null
     | undefined,
   tag: Tag,
@@ -121,6 +123,11 @@ export function attachTag(
     return;
   }
 
+  if (entity instanceof Primitive) {
+    (entity as any)[tagKey] = tag;
+    return;
+  }
+
   if (!entity.properties) {
     entity.properties = new PropertyBag();
   }
@@ -137,6 +144,7 @@ export function getTag(
     | Cesium3DTileset
     | Cesium3DTileFeature
     | Cesium3DTilePointFeature
+    | Primitive
     | Model
     | ImageryLayer
     | null
@@ -154,6 +162,10 @@ export function getTag(
     entity instanceof Model ||
     entity instanceof ImageryLayer
   ) {
+    return (entity as any)[tagKey];
+  }
+
+  if (entity instanceof Primitive) {
     return (entity as any)[tagKey];
   }
 

--- a/web/src/beta/lib/core/engines/Cesium/hooks.ts
+++ b/web/src/beta/lib/core/engines/Cesium/hooks.ts
@@ -11,8 +11,10 @@ import {
   Cartographic,
   SunLight,
   DirectionalLight,
+  Viewer as CesiumViewer,
+  Primitive,
+  ShadowMap,
 } from "cesium";
-import type { Viewer as CesiumViewer, ShadowMap } from "cesium";
 import CesiumDnD, { Context } from "cesium-dnd";
 import { isEqual } from "lodash-es";
 import { RefObject, useCallback, useEffect, useMemo, useRef } from "react";
@@ -20,7 +22,7 @@ import type { CesiumComponentRef, CesiumMovementEvent, RootEventTarget } from "r
 import { useCustomCompareCallback } from "use-custom-compare";
 
 import { ComputedFeature, DataType, SelectedFeatureInfo } from "@reearth/beta/lib/core/mantle";
-import { LayersRef, FEATURE_FLAGS, RequestingRenderMode } from "@reearth/beta/lib/core/Map";
+import { LayersRef, RequestingRenderMode } from "@reearth/beta/lib/core/Map";
 import { e2eAccessToken, setE2ECesiumViewer } from "@reearth/services/config";
 
 import type {
@@ -33,6 +35,7 @@ import type {
   MouseEvents,
   LayerEditEvent,
 } from "..";
+import { FEATURE_FLAGS } from "../../Crust";
 import { FORCE_REQUEST_RENDER, NO_REQUEST_RENDER, REQUEST_RENDER_ONCE } from "../../Map/hooks";
 import { TimelineManagerRef } from "../../Map/useTimelineManager";
 
@@ -317,7 +320,9 @@ export default ({
     }
   }, [camera, engineAPI]);
 
-  const prevSelectedEntity = useRef<Entity | Cesium3DTileset | InternalCesium3DTileFeature>();
+  const prevSelectedEntity = useRef<
+    Entity | Cesium3DTileset | InternalCesium3DTileFeature | Primitive
+  >();
   // manage layer selection
   useEffect(() => {
     const viewer = cesium.current?.cesiumElement;
@@ -585,6 +590,16 @@ export default ({
         if (tag) {
           onLayerSelect?.(tag.layerId, String(tag.featureId));
           prevSelectedEntity.current = model;
+        }
+        return;
+      }
+
+      if (target?.primitive && target.primitive instanceof Primitive) {
+        const primitive = target.primitive;
+        const tag = getTag(primitive);
+        if (tag) {
+          onLayerSelect?.(tag.layerId, String(tag.featureId));
+          prevSelectedEntity.current = primitive;
         }
         return;
       }

--- a/web/src/beta/lib/core/engines/Cesium/useEngineRef.ts
+++ b/web/src/beta/lib/core/engines/Cesium/useEngineRef.ts
@@ -168,13 +168,22 @@ export default function useEngineRef(
 
           const layerOrFeatureId = target;
           const entityFromFeatureId = findEntity(viewer, undefined, layerOrFeatureId, true);
+
+          if (entityFromFeatureId instanceof Cesium.Primitive) {
+            viewer.scene.camera.flyToBoundingSphere(
+              Cesium.BoundingSphere.fromTransformation(entityFromFeatureId.modelMatrix),
+            );
+            return;
+          }
+
           // `viewer.flyTo` doesn't support Cesium3DTileFeature.
           if (
             entityFromFeatureId &&
             !(
               entityFromFeatureId instanceof Cesium.Cesium3DTileFeature ||
               entityFromFeatureId instanceof Cesium.Cesium3DTilePointFeature ||
-              entityFromFeatureId instanceof Cesium.Model
+              entityFromFeatureId instanceof Cesium.Model ||
+              entityFromFeatureId instanceof Cesium.Primitive
             )
           ) {
             viewer.flyTo(entityFromFeatureId, options);
@@ -203,12 +212,21 @@ export default function useEngineRef(
             }
 
             const entityFromLayerId = findEntity(viewer, layerOrFeatureId);
+
+            if (entityFromLayerId instanceof Cesium.Primitive) {
+              viewer.scene.camera.flyToBoundingSphere(
+                Cesium.BoundingSphere.fromTransformation(entityFromLayerId.modelMatrix),
+              );
+              return;
+            }
+
             if (
               entityFromLayerId &&
               !(
                 entityFromLayerId instanceof Cesium.Cesium3DTileFeature ||
                 entityFromLayerId instanceof Cesium.Cesium3DTilePointFeature ||
-                entityFromLayerId instanceof Cesium.Model
+                entityFromLayerId instanceof Cesium.Model ||
+                entityFromLayerId instanceof Cesium.Primitive
               )
             ) {
               viewer.flyTo(entityFromLayerId, options);

--- a/web/src/beta/lib/core/engines/Cesium/utils.ts
+++ b/web/src/beta/lib/core/engines/Cesium/utils.ts
@@ -15,6 +15,7 @@ import {
   Scene,
   Viewer,
   Cesium3DTilePointFeature,
+  Primitive,
 } from "cesium";
 
 import { InfoboxProperty } from "@reearth/beta/lib/core/Crust/Infobox";
@@ -140,7 +141,7 @@ export function findEntity(
   layerId?: string,
   featureId?: string,
   withoutTileFeature?: boolean,
-): Entity | Cesium3DTileset | InternalCesium3DTileFeature | undefined {
+): Entity | Cesium3DTileset | InternalCesium3DTileFeature | Primitive | undefined {
   const id = featureId ?? layerId;
   const keyName = featureId ? "featureId" : "layerId";
   if (!id) return;
@@ -161,10 +162,10 @@ export function findEntity(
     }
   }
 
-  // Find Cesium3DTileset
+  // Find Cesium3DTileset or Primitive
   for (let i = 0; i < viewer.scene.primitives.length; i++) {
     const prim = viewer.scene.primitives.get(i);
-    if (!(prim instanceof Cesium3DTileset)) {
+    if (!(prim instanceof Cesium3DTileset) && !(prim instanceof Primitive)) {
       continue;
     }
 
@@ -179,7 +180,7 @@ export function findEntity(
     if (!prim.ready) continue;
 
     // Skip to search 3dtiles features if `withoutTileFeature` is `true`.
-    if (!withoutTileFeature) {
+    if (!withoutTileFeature && prim instanceof Cesium3DTileset) {
       const target = findFeatureFrom3DTile(prim.root, featureId);
       if (target) {
         return target;

--- a/web/src/beta/lib/core/mantle/types/appearance.ts
+++ b/web/src/beta/lib/core/mantle/types/appearance.ts
@@ -28,6 +28,7 @@ export type AppearanceTypes = {
   photooverlay: LegacyPhotooverlayAppearance;
   resource: ResourceAppearance;
   raster: RasterAppearance;
+  frustum: FrustumAppearance;
   transition: TransitionAppearance;
 };
 
@@ -141,6 +142,15 @@ export type ModelAppearance = {
   imageBasedLightIntensity?: number;
 };
 
+export type FrustumAppearance = {
+  show?: boolean;
+  color?: string;
+  opacity?: number;
+  zoom?: number;
+  aspectRatio?: number;
+  length?: number;
+};
+
 export type Cesium3DTilesAppearance = {
   show?: boolean;
   color?: string;
@@ -238,6 +248,8 @@ export type BoxAppearance = {
 export type TransitionAppearance = {
   useTransition?: boolean;
   translate?: [lng: number, lat: number, height: number];
+  rotate?: [heading: number, pitch: number, roll: number];
+  scale?: [x: number, y: number, z: number];
 };
 
 export const appearanceKeyObj: { [k in keyof AppearanceTypes]: 1 } = {
@@ -251,6 +263,7 @@ export const appearanceKeyObj: { [k in keyof AppearanceTypes]: 1 } = {
   photooverlay: 1,
   resource: 1,
   raster: 1,
+  frustum: 1,
   transition: 1,
 };
 


### PR DESCRIPTION
# Overview

I added frustum model.

![Screenshot 2023-12-15 at 19 05 04](https://github.com/reearth/reearth/assets/34934510/ef49b64a-8eda-452b-a691-0a16cd82863c)

Used for this one for VIEW3.0.

![Screenshot 2023-12-16 at 11 55 23](https://github.com/reearth/reearth/assets/34934510/4dfcee7c-7fb6-4ac5-aedf-b02354aaf767)


## What I've done

- Added frustum appearance and feature component
- Support flyTo for frustum
- Select frustum feature

## What I haven't done

- Show indicator when selecting, it's impossible due to Cesium doesn't support selecting Primitive.

## How I tested

```js
const id = reearth.layers.add({
      type: "simple",
      data: {
        type: "geojson",
        value: {
          type: "Feature",
          geometry: {
            type: "Point",
            coordinates: [0, 0, 1000],
          },
        },
      },
      frustum: {
        zoom: 1,
        color: "#00ff00",
        length: 10000,
      },
});
setTimeout(() => reearth.camera.flyTo(id), 100);
```

## Which point I want you to review particularly

## Memo
