### PR TITLE
chore(web): fix scene undefined bug in heatmap

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/Feature/HeatMap/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/HeatMap/index.tsx
@@ -47,6 +47,10 @@ export default memo(function HeatMap({ property, isVisible, layer, feature }: Pr
   const [visible, setVisible] = useState(false);
   useEffect(() => {
     const isVisible = (): boolean => {
+      if (!scene?.camera) {
+        return false;
+      }
+
       const camera = scene?.camera;
       const frustum = camera?.frustum;
       invariant(frustum instanceof PerspectiveFrustum);
@@ -92,6 +96,20 @@ export default memo(function HeatMap({ property, isVisible, layer, feature }: Pr
       .catch(() => {});
   }, [reversingImageNeeded, valueMap, visible]);
 
+  const hasBounds = !!bounds;
+
+  const geometry = useMemo(
+    () =>
+      meshImageData != null && hasBounds
+        ? turf.bboxPolygon([boudsRef[0], boudsRef[1], boudsRef[2], boudsRef[3]]).geometry
+        : undefined,
+    [hasBounds, boudsRef, meshImageData],
+  );
+
+  if (!scene) {
+    return null;
+  }
+
   const {
     contourSpacing = maxValue != null
       ? Math.max(10, maxValue / 20)
@@ -102,15 +120,6 @@ export default memo(function HeatMap({ property, isVisible, layer, feature }: Pr
     minValue != null && maxValue != null
       ? [minValue, maxValue]
       : extendRange([0, 100], [0, meshImageData?.outlierThreshold || 0]);
-
-  const hasBounds = !!bounds;
-  const geometry = useMemo(
-    () =>
-      meshImageData != null && hasBounds
-        ? turf.bboxPolygon([boudsRef[0], boudsRef[1], boudsRef[2], boudsRef[3]]).geometry
-        : undefined,
-    [hasBounds, boudsRef, meshImageData],
-  );
 
   if (!isVisible || meshImageData == null || geometry == null) {
     return null;


### PR DESCRIPTION
# Overview
This PR fixes a bug produced by `HeatMap` component when camera is being moved is scene becomes `undefined`.
![image](https://github.com/reearth/reearth/assets/42397980/e3fa5606-124e-409c-bd3c-5f619c22b3f5)

