### PR TITLE
chore(web): disable PBR when material has texture

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/Shaders/CustomShaders/NonPBRLightingShader.ts
+++ b/web/src/beta/lib/core/engines/Cesium/Shaders/CustomShaders/NonPBRLightingShader.ts
@@ -11,7 +11,26 @@ export const NonPBRLightingShader = new CustomShader({
   translucencyMode: CustomShaderTranslucencyMode.OPAQUE,
   fragmentShaderText: /* glsl */ `
     void fragmentMain(FragmentInput fsInput, inout czm_modelMaterial material) {
-      material.diffuse = vec3(1.0);
+      // Disable PBR for the material which has texture
+      // ref: https://github.com/CesiumGS/cesium/blob/50468896ca7d6071e0f8fb359598c03879fbf0a2/packages/engine/Source/Shaders/Model/MaterialStageFS.glsl#L71-L85
+      #ifdef HAS_BASE_COLOR_TEXTURE 
+        vec4 baseColorWithAlpha = vec4(1.0);
+        vec2 baseColorTexCoords = TEXCOORD_BASE_COLOR;
+
+        #ifdef HAS_BASE_COLOR_TEXTURE_TRANSFORM
+          baseColorTexCoords = computeTextureTransform(baseColorTexCoords, u_baseColorTextureTransform);
+        #endif
+
+        baseColorWithAlpha = czm_srgbToLinear(texture(u_baseColorTexture, baseColorTexCoords));
+
+        #ifdef HAS_BASE_COLOR_FACTOR
+          baseColorWithAlpha *= u_baseColorFactor;
+        #endif
+
+        material.diffuse = baseColorWithAlpha.rgb;
+      #else
+        material.diffuse = vec3(1.);
+      #endif
       material.specular = vec3(0.0);
       material.emissive = vec3(0.0);
       material.alpha = 1.0;


### PR DESCRIPTION
# Overview

Before this change, texture was disappear when disabling PBR. So I fixed this issue.

|Non-PBR with texture|PBR with texture|
|:--:|:--:|
|![Screenshot 2024-01-22 at 13 08 09](https://github.com/reearth/reearth/assets/34934510/078cc224-1958-459b-bd20-893e4e31bce0)|![Screenshot 2024-01-22 at 13 08 37](https://github.com/reearth/reearth/assets/34934510/935ece90-e381-4b47-a96b-e24ef5d0930e)|

## What I've done

## What I haven't done

## How I tested

```js
const id = reearth.layers.add({
    type: "simple",
    data: {
        type: "3dtiles",
        url: "https://assets.cms.plateau.reearth.io/assets/e3/a75ee8-6621-48d4-97ee-d38d10b23677/13100_tokyo23-ku_2022_3dtiles_1_2_op_bldg_13101_chiyoda-ku_lod2/tileset.json",
    },
    "3dtiles": {
        pbr: false
    }
});
setTimeout(() => reearth.camera.flyTo(id), 100);
```

## Which point I want you to review particularly

## Memo
