### PR TITLE
chore(web): add startsWith func in style evaluator

### DIFF
--- a/web/src/beta/lib/core/mantle/evaluator/simple/expression/functions/binaryFunctions.ts
+++ b/web/src/beta/lib/core/mantle/evaluator/simple/expression/functions/binaryFunctions.ts
@@ -28,10 +28,6 @@ function getEvaluateBinaryComponentwise(operation: any, allowScalar: boolean): B
       return operation(left, right);
     }
 
-    if (typeof left === "number" && typeof right === "number") {
-      return operation(left, right);
-    }
-
     if (typeof left === "string" && typeof right === "string") {
       return operation(left, right);
     }

--- a/web/src/beta/lib/core/mantle/evaluator/simple/expression/functions/binaryFunctions.ts
+++ b/web/src/beta/lib/core/mantle/evaluator/simple/expression/functions/binaryFunctions.ts
@@ -1,4 +1,4 @@
-type BinaryFunction = (call: string, left: number, right: number) => number;
+type BinaryFunction = (call: string, left: number | string, right: number | string) => any;
 
 export function getEvaluateBinaryFunction(call: string): (feature: any) => number {
   const evaluate = binaryFunctions[call];
@@ -14,6 +14,7 @@ export const binaryFunctions: { [key: string]: BinaryFunction } = {
   pow: getEvaluateBinaryComponentwise(Math.pow, false),
   min: getEvaluateBinaryComponentwise(Math.min, true),
   max: getEvaluateBinaryComponentwise(Math.max, true),
+  startsWith: getEvaluateBinaryComponentwise(startsWith, false),
 };
 
 function getEvaluateBinaryComponentwise(operation: any, allowScalar: boolean): BinaryFunction {
@@ -27,8 +28,20 @@ function getEvaluateBinaryComponentwise(operation: any, allowScalar: boolean): B
       return operation(left, right);
     }
 
+    if (typeof left === "number" && typeof right === "number") {
+      return operation(left, right);
+    }
+
+    if (typeof left === "string" && typeof right === "string") {
+      return operation(left, right);
+    }
+
     throw new Error(
       `Function "${call}" requires vector or number arguments of matching types. Arguments are ${left} and ${right}.`,
     );
   };
+}
+
+function startsWith(left: string, right: string): boolean {
+  return left.startsWith(right);
 }

--- a/web/src/beta/lib/core/mantle/evaluator/simple/index.test.ts
+++ b/web/src/beta/lib/core/mantle/evaluator/simple/index.test.ts
@@ -533,3 +533,35 @@ describe("Conditional styling", () => {
     });
   });
 });
+
+test("startsWith function", () => {
+  expect(
+    evalLayerAppearances(
+      {
+        marker: {
+          pointColor: "#FF0000",
+          pointSize: {
+            expression: {
+              conditions: [
+                ["startsWith('abc', 'a')", "200"],
+                ["true", "1"],
+              ],
+            },
+          },
+        },
+      },
+      {
+        id: "x",
+        type: "simple",
+        properties: {
+          blah: "value",
+        },
+      },
+    ),
+  ).toEqual({
+    marker: {
+      pointColor: "#FF0000", // blue
+      pointSize: 200,
+    },
+  });
+});


### PR DESCRIPTION
# Overview
This PR adds support for `startsWith` to NLS style expression evaluator and corresponding test has been added.
