### PR TITLE
chore(web): support rootProperties built-in variables in evaluator

### DIFF
--- a/web/src/beta/lib/core/mantle/evaluator/simple/expression/node.ts
+++ b/web/src/beta/lib/core/mantle/evaluator/simple/expression/node.ts
@@ -189,6 +189,8 @@ export class Node {
       property = feature.properties[String(this._value)];
     } else if (String(this._value) === "id") {
       property = feature?.id;
+    } else if (feature && String(this._value) === "rootProperties") {
+      property = feature.properties;
     }
     if (typeof property === "undefined") {
       property = "";


### PR DESCRIPTION
# Overview

I added `rootProperties` built-in variables to access to some variables which has invalid character like `:`, `(` etc...
So we might be able to remove [replaceReservedWord](https://github.com/reearth/reearth/blob/main/web/src/beta/lib/core/mantle/evaluator/simple/expression/variableReplacer.ts#L109) in the future.

## What I've done

## What I haven't done

## How I tested

```js
const id = reearth.layers.add({
    type: "simple",
    data: {
        type: "3dtiles",
        url: "https://assets.cms.plateau.reearth.io/assets/a2/33dad2-cb07-4cfa-90fa-724ac45c9aea/40202_omuta-shi_city_2023_citygml_1_op_bldg_3dtiles_lod1/tileset.json"
    },
    "3dtiles": {
        color: {
            expression: "${rootProperties['bldg:measuredHeight']} >= 20 ? color('red') : color('blue')"
        }
    }
});
setTimeout(() => {
  reearth.camera.flyTo(id);
}, 100);
```

## Which point I want you to review particularly

## Memo
