### PR TITLE
chore(web): fix statement for Hideindicator and viewer.selectedEntity

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/hooks.ts
+++ b/web/src/beta/lib/core/engines/Cesium/hooks.ts
@@ -361,6 +361,8 @@ export default ({
     const tag = getTag(entity);
     if (entity instanceof Entity && !tag?.hideIndicator) {
       viewer.selectedEntity = entity;
+    } else {
+      viewer.selectedEntity = undefined;
     }
 
     prevSelectedEntity.current = entity;
@@ -538,7 +540,14 @@ export default ({
       const viewer = cesium.current?.cesiumElement;
       if (!viewer || viewer.isDestroyed()) return;
 
-      viewer.selectedEntity = undefined;
+      const entity =
+        findEntity(viewer, undefined, selectedLayerId?.featureId) ||
+        findEntity(viewer, selectedLayerId?.layerId);
+
+      const tag = getTag(entity);
+      if (!entity || (entity instanceof Entity && tag?.hideIndicator)) {
+        viewer.selectedEntity = undefined;
+      }
 
       if (target && "id" in target && target.id instanceof Entity && isSelectable(target.id)) {
         const tag = getTag(target.id);
@@ -565,6 +574,8 @@ export default ({
         prevSelectedEntity.current = target.id;
         if (target.id instanceof Entity && !tag?.hideIndicator) {
           viewer.selectedEntity = target.id;
+        } else {
+          viewer.selectedEntity = undefined;
         }
         return;
       }
@@ -689,11 +700,20 @@ export default ({
         }
       }
 
-      viewer.selectedEntity = undefined;
+      if (!entity || (entity instanceof Entity && tag?.hideIndicator)) {
+        viewer.selectedEntity = undefined;
+      }
 
       onLayerSelect?.();
     },
-    [onLayerSelect, mouseEventHandles, layersRef, featureFlags],
+    [
+      onLayerSelect,
+      mouseEventHandles,
+      layersRef,
+      featureFlags,
+      selectedLayerId?.featureId,
+      selectedLayerId?.layerId,
+    ],
   );
 
   // E2E test

--- a/web/src/beta/lib/core/engines/Cesium/hooks.ts
+++ b/web/src/beta/lib/core/engines/Cesium/hooks.ts
@@ -538,6 +538,8 @@ export default ({
       const viewer = cesium.current?.cesiumElement;
       if (!viewer || viewer.isDestroyed()) return;
 
+      viewer.selectedEntity = undefined;
+
       if (target && "id" in target && target.id instanceof Entity && isSelectable(target.id)) {
         const tag = getTag(target.id);
         const layer = tag?.layerId
@@ -686,6 +688,8 @@ export default ({
           }
         }
       }
+
+      viewer.selectedEntity = undefined;
 
       onLayerSelect?.();
     },

--- a/web/src/beta/lib/core/engines/Cesium/hooks.ts
+++ b/web/src/beta/lib/core/engines/Cesium/hooks.ts
@@ -361,8 +361,6 @@ export default ({
     const tag = getTag(entity);
     if (entity instanceof Entity && !tag?.hideIndicator) {
       viewer.selectedEntity = entity;
-    } else {
-      viewer.selectedEntity = undefined;
     }
 
     prevSelectedEntity.current = entity;
@@ -540,15 +538,6 @@ export default ({
       const viewer = cesium.current?.cesiumElement;
       if (!viewer || viewer.isDestroyed()) return;
 
-      const entity =
-        findEntity(viewer, undefined, selectedLayerId?.featureId) ||
-        findEntity(viewer, selectedLayerId?.layerId);
-
-      const tag = getTag(entity);
-      if (!entity || (entity instanceof Entity && tag?.hideIndicator)) {
-        viewer.selectedEntity = undefined;
-      }
-
       if (target && "id" in target && target.id instanceof Entity && isSelectable(target.id)) {
         const tag = getTag(target.id);
         const layer = tag?.layerId
@@ -574,8 +563,6 @@ export default ({
         prevSelectedEntity.current = target.id;
         if (target.id instanceof Entity && !tag?.hideIndicator) {
           viewer.selectedEntity = target.id;
-        } else {
-          viewer.selectedEntity = undefined;
         }
         return;
       }
@@ -700,19 +687,9 @@ export default ({
         }
       }
 
-      if (!entity || (entity instanceof Entity && tag?.hideIndicator)) {
-        viewer.selectedEntity = undefined;
-      }
       onLayerSelect?.();
     },
-    [
-      onLayerSelect,
-      mouseEventHandles,
-      layersRef,
-      featureFlags,
-      selectedLayerId?.featureId,
-      selectedLayerId?.layerId,
-    ],
+    [onLayerSelect, mouseEventHandles, layersRef, featureFlags],
   );
 
   // E2E test


### PR DESCRIPTION
# Overview
deleted if statement for viewer.selectedEntity = undefined;

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly


## Memo

First viewer.selectedEntity = undefined; (L541): This line is used within the handleClick function to clear the selection under certain conditions, such as when a specific type of entity is clicked but deemed inappropriate to remain selected. It clears the currently selected entity if the user's click action is determined not to result in a valid selection

Second viewer.selectedEntity = undefined; (L691): This line is placed at the end of the handleClick function and is used to ensure there is no selected entity left after the click event has been fully processed. It acts as a final check to reset the selection state if no selection should be made based on the user's action or specific conditions dictate that the selection should be cleared
