### PR TITLE
chore(web): extend sketch api

### DIFF
--- a/web/src/beta/features/Editor/useSketch.tsx
+++ b/web/src/beta/features/Editor/useSketch.tsx
@@ -1,5 +1,4 @@
 import { MutableRefObject, useCallback, useEffect, useRef, useState } from "react";
-import { v4 as uuidv4 } from "uuid";
 
 import { MapRef } from "@reearth/beta/lib/core/Crust/types";
 import { SketchFeature, SketchType } from "@reearth/beta/lib/core/Map/Sketch/types";
@@ -41,8 +40,7 @@ export default ({
   const handleSketchFeatureCreate = useCallback(
     async (feature: SketchFeature | null) => {
       // TODO: create a new layer if there is no selected sketch layer
-      if (!selectedLayer?.id || !selectedLayer.config?.data?.isSketchLayer) return;
-      const featureId = uuidv4();
+      if (!feature || !selectedLayer?.id || !selectedLayer.config?.data?.isSketchLayer) return;
       // TODO: support custom properties
       const customProperties = {};
       await handleLayerConfigUpdate({
@@ -56,8 +54,8 @@ export default ({
                 ...(selectedLayer.config?.data?.value?.features ?? []),
                 {
                   ...feature,
-                  id: featureId,
-                  properties: { ...feature?.properties, ...customProperties },
+                  id: feature.properties.id,
+                  properties: { ...feature.properties, ...customProperties },
                 },
               ],
             },
@@ -66,7 +64,7 @@ export default ({
       });
       pendingSketchSelectionRef.current = {
         layerId: selectedLayer.id,
-        featureId,
+        featureId: feature.properties.id,
       };
     },
     [selectedLayer, handleLayerConfigUpdate],

--- a/web/src/beta/lib/core/Crust/Plugins/hooks.ts
+++ b/web/src/beta/lib/core/Crust/Plugins/hooks.ts
@@ -154,6 +154,9 @@ export default function ({
       setType: (type: SketchType | undefined) => mapRef?.current?.sketch?.setType(type, "plugin"),
       setColor: mapRef?.current?.sketch?.setColor,
       setDefaultAppearance: mapRef?.current?.sketch?.setDefaultAppearance,
+      createDataOnly: mapRef?.current?.sketch?.createDataOnly,
+      allowRightClickToAbort: mapRef?.current?.sketch?.allowRightClickToAbort,
+      allowAutoResetInteractionMode: mapRef?.current?.sketch?.allowAutoResetInteractionMode,
     }),
     [mapRef],
   );

--- a/web/src/beta/lib/core/Crust/Plugins/plugin_types.ts
+++ b/web/src/beta/lib/core/Crust/Plugins/plugin_types.ts
@@ -85,6 +85,7 @@ export type Reearth = {
       ) => void;
       findFeatureById?: (layerId: string, featureId: string) => Feature | undefined;
       findFeaturesByIds?: (layerId: string, featureId: string[]) => Feature[] | undefined;
+      selectFeature?: (layerId: string, featureId: string) => void;
       selectFeatures?: (layers: { layerId?: string; featureId?: string[] }[]) => void;
       selectionReason?: LayerSelectionReason;
       // For compat
@@ -427,6 +428,9 @@ export type Sketch = {
   readonly setType?: (type: SketchType | undefined) => void;
   readonly setColor?: (color: string) => void;
   readonly setDefaultAppearance?: (appearance: SketchAppearance) => void;
+  readonly createDataOnly?: (dataOnly: boolean) => void;
+  readonly allowRightClickToAbort?: (allow: boolean) => void;
+  readonly allowAutoResetInteractionMode?: (allow: boolean) => void;
 };
 
 /** Cesium API: available only when the plugin is a primitive */

--- a/web/src/beta/lib/core/Map/Sketch/hooks.ts
+++ b/web/src/beta/lib/core/Map/Sketch/hooks.ts
@@ -107,6 +107,7 @@ export default function useHooks({
       return null;
     }
     return feature(geometry, {
+      id: uuidv4(),
       type: geoOptions.type,
       positions: geoOptions.controlPoints,
       extrudedHeight,
@@ -133,7 +134,6 @@ export default function useHooks({
 
   const pluginSketchLayerCreate = useCallback(
     (feature: SketchFeature) => {
-      const featureId = uuidv4();
       const newLayer = layersRef.current?.add({
         type: "simple",
         data: {
@@ -141,12 +141,12 @@ export default function useHooks({
           isSketchLayer: true,
           value: {
             type: "FeatureCollection",
-            features: [{ ...feature, id: featureId }],
+            features: [{ ...feature, id: feature.properties.id }],
           },
         },
         ...defaultAppearance,
       });
-      return { layerId: newLayer?.id, featureId };
+      return { layerId: newLayer?.id, featureId: feature.properties.id };
     },
     [layersRef, defaultAppearance],
   );
@@ -154,7 +154,6 @@ export default function useHooks({
   const pluginSketchLayerFeatureAdd = useCallback(
     (layer: LazyLayer, feature: SketchFeature) => {
       if (layer.type !== "simple") return {};
-      const featureId = uuidv4();
       layersRef.current?.override(layer.id, {
         data: {
           ...layer.data,
@@ -163,12 +162,12 @@ export default function useHooks({
             type: "FeatureCollection",
             features: [
               ...((layer.computed?.layer as LayerSimple)?.data?.value?.features ?? []),
-              { ...feature, id: featureId },
+              { ...feature, id: feature.properties.id },
             ],
           },
         },
       });
-      return { layerId: layer.id, featureId };
+      return { layerId: layer.id, featureId: feature.properties.id };
     },
     [layersRef],
   );

--- a/web/src/beta/lib/core/Map/Sketch/hooks.ts
+++ b/web/src/beta/lib/core/Map/Sketch/hooks.ts
@@ -78,6 +78,9 @@ export default function useHooks({
   const [defaultAppearance, updateDefaultAppearance] = useState<SketchAppearance | undefined>(
     PRESET_APPEARANCE,
   );
+  const createDataOnlyForPluginEnabledRef = useRef(false);
+  const allowRightClickToAbortEnabledRef = useRef(true);
+  const allowAutoResetInteractionModeRef = useRef(true);
 
   const [geometryOptions, setGeometryOptions] = useState<GeometryOptionsXYZ | null>(null);
   const [extrudedHeight, setExtrudedHeight] = useState(0);
@@ -95,6 +98,18 @@ export default function useHooks({
 
   const setDefaultAppearance = useCallback((appearance: SketchAppearance) => {
     updateDefaultAppearance(merge(cloneDeep(PRESET_APPEARANCE), appearance));
+  }, []);
+
+  const createDataOnly = useCallback((dataOnly: boolean) => {
+    createDataOnlyForPluginEnabledRef.current = !!dataOnly;
+  }, []);
+
+  const allowRightClickToAbort = useCallback((allow: boolean) => {
+    allowRightClickToAbortEnabledRef.current = !!allow;
+  }, []);
+
+  const allowAutoResetInteractionMode = useCallback((allow: boolean) => {
+    allowAutoResetInteractionModeRef.current = !!allow;
   }, []);
 
   const createFeature = useCallback(() => {
@@ -200,33 +215,38 @@ export default function useHooks({
         onSketchFeatureCreate?.(feature);
         return;
       }
-      const selectedLayer = layersRef.current?.selectedLayer();
-      const { layerId, featureId } =
-        selectedLayer?.id?.length !== PLUGIN_LAYER_ID_LENGTH ||
-        selectedLayer.type !== "simple" ||
-        selectedLayer.computed?.layer.type !== "simple"
-          ? pluginSketchLayerCreate(feature)
-          : pluginSketchLayerFeatureAdd(selectedLayer, feature);
 
-      if (layerId && featureId) {
-        requestAnimationFrame(() => {
-          onLayerSelect?.(
-            layerId,
-            featureId,
-            layerId
-              ? () =>
-                  new Promise(resolve => {
-                    // Wait until computed feature is ready
-                    queueMicrotask(() => {
-                      resolve(layersRef.current?.findById?.(layerId)?.computed);
-                    });
-                  })
-              : undefined,
-            undefined,
-            undefined,
-          );
-        });
-        onPluginSketchFeatureCreated?.({ layerId, featureId });
+      if (!createDataOnlyForPluginEnabledRef.current) {
+        const selectedLayer = layersRef.current?.selectedLayer();
+        const { layerId, featureId } =
+          selectedLayer?.id?.length !== PLUGIN_LAYER_ID_LENGTH ||
+          selectedLayer.type !== "simple" ||
+          selectedLayer.computed?.layer.type !== "simple"
+            ? pluginSketchLayerCreate(feature)
+            : pluginSketchLayerFeatureAdd(selectedLayer, feature);
+
+        if (layerId && featureId) {
+          requestAnimationFrame(() => {
+            onLayerSelect?.(
+              layerId,
+              featureId,
+              layerId
+                ? () =>
+                    new Promise(resolve => {
+                      // Wait until computed feature is ready
+                      queueMicrotask(() => {
+                        resolve(layersRef.current?.findById?.(layerId)?.computed);
+                      });
+                    })
+                : undefined,
+              undefined,
+              undefined,
+            );
+          });
+          onPluginSketchFeatureCreated?.({ layerId, featureId, feature });
+        }
+      } else {
+        onPluginSketchFeatureCreated?.({ feature });
       }
     },
     [
@@ -451,6 +471,9 @@ export default function useHooks({
   );
 
   const handleRightClick = useCallback(() => {
+    if (!allowRightClickToAbortEnabledRef.current) {
+      return;
+    }
     if (type !== undefined) {
       updateType(undefined);
     }
@@ -551,15 +574,34 @@ export default function useHooks({
   }, [type, send, updateGeometryOptions]);
 
   useEffect(() => {
-    overrideInteractionMode?.(type ? "sketch" : "default");
+    if (type) {
+      overrideInteractionMode?.("sketch");
+    } else if (allowAutoResetInteractionModeRef.current) {
+      overrideInteractionMode?.("default");
+    }
+
     onSketchTypeChange?.(type, from);
   }, [type, from, overrideInteractionMode, onSketchTypeChange]);
 
-  useImperativeHandle(ref, () => ({ setType, setColor, setDefaultAppearance }), [
-    setType,
-    setColor,
-    setDefaultAppearance,
-  ]);
+  useImperativeHandle(
+    ref,
+    () => ({
+      setType,
+      setColor,
+      setDefaultAppearance,
+      createDataOnly,
+      allowRightClickToAbort,
+      allowAutoResetInteractionMode,
+    }),
+    [
+      setType,
+      setColor,
+      setDefaultAppearance,
+      createDataOnly,
+      allowRightClickToAbort,
+      allowAutoResetInteractionMode,
+    ],
+  );
 
   return {
     state,

--- a/web/src/beta/lib/core/Map/Sketch/preset.ts
+++ b/web/src/beta/lib/core/Map/Sketch/preset.ts
@@ -5,6 +5,7 @@ export const PRESET_APPEARANCE: SketchAppearance = {
     height: 0,
     heightReference: "clamp",
     hideIndicator: true,
+    selectedFeatureColor: "#00bebe",
   },
   polygon: {
     classificationType: "terrain",

--- a/web/src/beta/lib/core/Map/Sketch/types.ts
+++ b/web/src/beta/lib/core/Map/Sketch/types.ts
@@ -21,6 +21,7 @@ export type GeometryOptionsXYZ = {
 export type SketchFeature = GeojsonFeature<
   Polygon | MultiPolygon | Point | LineString,
   {
+    id: string;
     type: SketchType;
     positions: readonly Position3d[];
     extrudedHeight: number;

--- a/web/src/beta/lib/core/Map/Sketch/types.ts
+++ b/web/src/beta/lib/core/Map/Sketch/types.ts
@@ -29,8 +29,9 @@ export type SketchFeature = GeojsonFeature<
 >;
 
 export type SketchEventProps = {
-  layerId: string;
-  featureId: string;
+  layerId?: string;
+  featureId?: string;
+  feature?: SketchFeature;
 };
 
 export type SketchEventCallback = (event: SketchEventProps) => void;

--- a/web/src/beta/lib/core/Map/ref.ts
+++ b/web/src/beta/lib/core/Map/ref.ts
@@ -114,6 +114,9 @@ const sketchRefKeys: FunctionKeys<SketchRef> = {
   setType: 1,
   setColor: 1,
   setDefaultAppearance: 1,
+  createDataOnly: 1,
+  allowRightClickToAbort: 1,
+  allowAutoResetInteractionMode: 1,
 };
 
 export function mapRef({

--- a/web/src/beta/lib/core/Map/types/index.ts
+++ b/web/src/beta/lib/core/Map/types/index.ts
@@ -489,4 +489,7 @@ export type SketchRef = {
   setType: (type: SketchType | undefined, from?: "editor" | "plugin") => void;
   setColor: (color: string) => void;
   setDefaultAppearance: (appearance: SketchAppearance) => void;
+  createDataOnly: (dataOnly: boolean) => void;
+  allowRightClickToAbort: (allow: boolean) => void;
+  allowAutoResetInteractionMode: (allow: boolean) => void;
 };


### PR DESCRIPTION
# Overview

This PR extended sketch API.

```ts
  readonly createDataOnly?: (dataOnly: boolean) => void;
  readonly allowRightClickToAbort?: (allow: boolean) => void;
  readonly allowAutoResetInteractionMode?: (allow: boolean) => void;
```

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
