### PR TITLE
chore(web): set overridden layers ref immediately

### DIFF
--- a/web/src/beta/lib/core/Map/Layers/hooks.ts
+++ b/web/src/beta/lib/core/Map/Layers/hooks.ts
@@ -379,13 +379,18 @@ export default function useHooks({
       }
 
       const layer2 = { id, ...omit(rawLayer, "id", "type", "children") } as Layer;
-      setOverridenLayers(layers => {
-        const i = layers.findIndex(l => l.id === id);
-        const updated =
-          i < 0 ? [...layers, layer2] : [...layers.slice(0, i), layer2, ...layers.slice(i + 1)];
-        overriddenLayersRef.current = updated;
-        return updated;
-      });
+      const currentOverriddenlayers = overriddenLayersRef.current;
+      const i = currentOverriddenlayers.findIndex(l => l.id === id);
+      const updated =
+        i < 0
+          ? [...currentOverriddenlayers, layer2]
+          : [
+              ...currentOverriddenlayers.slice(0, i),
+              layer2,
+              ...currentOverriddenlayers.slice(i + 1),
+            ];
+      overriddenLayersRef.current = updated;
+      setOverridenLayers(updated);
     },
     [layerMap],
   );
@@ -435,11 +440,10 @@ export default function useHooks({
         );
         return newLayers;
       });
-      setOverridenLayers(layers => {
-        const updated = layers.filter(l => !ids.includes(l.id));
-        overriddenLayersRef.current = updated;
-        return updated;
-      });
+      const currentOverriddenlayers = overriddenLayersRef.current;
+      const updated = currentOverriddenlayers.filter(l => !ids.includes(l.id));
+      overriddenLayersRef.current = updated;
+      setOverridenLayers(updated);
     },
     [layerMap, atomMap, lazyLayerMap, initialSelectedLayer, showLayer, select],
   );
@@ -605,11 +609,10 @@ export default function useHooks({
       lazyLayerMap.delete(k);
       showLayer(k);
     });
-    setOverridenLayers(layers => {
-      const updated = layers.filter(l => !deleted?.includes(l.id));
-      overriddenLayersRef.current = updated;
-      return updated;
-    });
+    const currentOverriddenlayers = overriddenLayersRef.current;
+    const updated = currentOverriddenlayers.filter(l => !deleted?.includes(l.id));
+    overriddenLayersRef.current = updated;
+    setOverridenLayers(updated);
 
     prevLayers.current = layers;
   }, [atomMap, layers, layerMap, lazyLayerMap, setOverridenLayers, showLayer]);

--- a/web/src/beta/lib/core/Map/Layers/hooks.ts
+++ b/web/src/beta/lib/core/Map/Layers/hooks.ts
@@ -320,7 +320,6 @@ export default function useHooks({
   );
 
   const overriddenLayersRef = useRef(overriddenLayers);
-  overriddenLayersRef.current = overriddenLayers;
 
   const override = useCallback(
     (id: string, layer?: (Partial<Layer> & { property?: any }) | null) => {
@@ -382,8 +381,10 @@ export default function useHooks({
       const layer2 = { id, ...omit(rawLayer, "id", "type", "children") } as Layer;
       setOverridenLayers(layers => {
         const i = layers.findIndex(l => l.id === id);
-        if (i < 0) return [...layers, layer2];
-        return [...layers.slice(0, i), layer2, ...layers.slice(i + 1)];
+        const updated =
+          i < 0 ? [...layers, layer2] : [...layers.slice(0, i), layer2, ...layers.slice(i + 1)];
+        overriddenLayersRef.current = updated;
+        return updated;
       });
     },
     [layerMap],
@@ -434,7 +435,11 @@ export default function useHooks({
         );
         return newLayers;
       });
-      setOverridenLayers(layers => layers.filter(l => !ids.includes(l.id)));
+      setOverridenLayers(layers => {
+        const updated = layers.filter(l => !ids.includes(l.id));
+        overriddenLayersRef.current = updated;
+        return updated;
+      });
     },
     [layerMap, atomMap, lazyLayerMap, initialSelectedLayer, showLayer, select],
   );
@@ -600,7 +605,11 @@ export default function useHooks({
       lazyLayerMap.delete(k);
       showLayer(k);
     });
-    setOverridenLayers(layers => layers.filter(l => !deleted?.includes(l.id)));
+    setOverridenLayers(layers => {
+      const updated = layers.filter(l => !deleted?.includes(l.id));
+      overriddenLayersRef.current = updated;
+      return updated;
+    });
 
     prevLayers.current = layers;
   }, [atomMap, layers, layerMap, lazyLayerMap, setOverridenLayers, showLayer]);


### PR DESCRIPTION
# Overview

`override`for layer and `updateStyle` could be called independently but in one frame, `overriddenLayers` state is not able to be updated, but `overriddenLayersRef.current = overriddenLayers;` is been called in each call, therefore the later update refs value from old `overriddenLayers` state and the first override could be override back.

This PR removes `overriddenLayersRef.current = overriddenLayers;`. Instead it set `overriddenLayersRef.current` to latest value at everywhere `setOverridenLayers` been used. When using overridden value use overriddenLayersRef.current to make sure it's getting the latest one.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
