### PR TITLE
chore(web): correct timeline update params

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/Feature/Resource/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Resource/index.tsx
@@ -138,9 +138,9 @@ export default function Resource({
         timelineManagerRef?.current?.commit({
           cmd: "SET_TIME",
           payload: {
-            start: JulianDate.toDate(ds.clock.currentTime),
-            stop: JulianDate.toDate(ds.clock.startTime),
-            current: JulianDate.toDate(ds.clock.stopTime),
+            start: JulianDate.toDate(ds.clock.startTime),
+            stop: JulianDate.toDate(ds.clock.stopTime),
+            current: JulianDate.toDate(ds.clock.currentTime),
           },
           committer: {
             source: "featureResource",


### PR DESCRIPTION
# Overview

The timeline update params are incorrect.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
