### PR TITLE
chore(web): fix resource appearance to be able to get the information of the feature

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/Feature/Resource/index.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Resource/index.tsx
@@ -14,7 +14,7 @@ import {
   type FeatureProps,
 } from "../utils";
 
-import { attachStyle } from "./utils";
+import { attachStyle, makeFeatureId } from "./utils";
 
 export type Props = FeatureProps<Property>;
 export type Property = ResourceAppearance;
@@ -113,6 +113,11 @@ export default function Resource({
   });
   const handleLoad = useCallback(
     (ds: DataSource) => {
+      ds.entities.values.forEach(e =>
+        requestAnimationFrame(() => {
+          attachTag(e, { layerId: layer?.id, featureId: makeFeatureId(e) });
+        }),
+      );
       if (!updateClock) {
         if (
           initialClock.current.current &&

--- a/web/src/beta/lib/core/engines/Cesium/Feature/Resource/utils.ts
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/Resource/utils.ts
@@ -117,6 +117,8 @@ const hasAppearance = <
   return !!(extractSimpleLayer(layer)?.[namePair[0]] || entity[namePair[1]]);
 };
 
+export const makeFeatureId = (e: Entity) => String(e.id);
+
 export const attachStyle = (
   entity: Entity,
   layer: ComputedLayer | undefined,
@@ -136,7 +138,7 @@ export const attachStyle = (
     const coordinates = [position?.x ?? 0, position?.y ?? 0, position?.z ?? 0];
     const feature: Feature = {
       type: "feature",
-      id: String(entity.id),
+      id: makeFeatureId(entity),
       geometry: {
         type: "Point",
         coordinates,
@@ -270,7 +272,7 @@ export const attachStyle = (
     ]);
     const feature: Feature = {
       type: "feature",
-      id: String(entity.id),
+      id: makeFeatureId(entity),
       geometry: {
         type: "LineString",
         coordinates,
@@ -320,7 +322,7 @@ export const attachStyle = (
     );
     const feature: Feature = {
       type: "feature",
-      id: String(entity.id),
+      id: makeFeatureId(entity),
       geometry: {
         type: "Polygon",
         coordinates,


### PR DESCRIPTION
# Overview

I fixed to be able to show infobox in VIEW3.0 in resource appearance with geojson.

## What I've done

## What I haven't done

## How I tested

You can use this dataset to test in VIEW3. It should show the feature inspector, but it doesn't show anything before.
`地震動予測（揺れやすさ）区域モデル（港区）`

## Which point I want you to review particularly

## Memo
