### PR TITLE
chore(web): add colon as reserved word in style evaluator

### DIFF
--- a/web/src/beta/lib/core/mantle/evaluator/simple/expression/variableReplacer.ts
+++ b/web/src/beta/lib/core/mantle/evaluator/simple/expression/variableReplacer.ts
@@ -104,10 +104,11 @@ const RESERVED_WORDS: Record<string, string> = {
   "(": makeReservedWord("opened_parentheses"),
   ")": makeReservedWord("closed_parentheses"),
   "-": makeReservedWord("hyphen"),
+  ":": makeReservedWord("colon"),
 };
 
 const replaceReservedWord = (word: string) => {
-  const wordFiltered = word.replace(/-/g, RESERVED_WORDS["-"]);
+  const wordFiltered = word.replace(/-/g, RESERVED_WORDS["-"]).replace(/:/g, RESERVED_WORDS[":"]);
   if (!/(\]|\)|\})[^[.]+$/.test(wordFiltered)) {
     return wordFiltered;
   }

--- a/web/src/beta/lib/core/mantle/evaluator/simple/index.test.ts
+++ b/web/src/beta/lib/core/mantle/evaluator/simple/index.test.ts
@@ -601,3 +601,56 @@ test("Array equality with value", () => {
     },
   });
 });
+
+test("Conditions with JSONPath, strictly equal and JSONPath result, colon", async () => {
+  expect(
+    await evalLayerAppearances(
+      {
+        marker: {
+          pointColor: "#FF0000",
+          pointSize: {
+            expression: {
+              conditions: [
+                ["${$.phone:Numbers[:1].type} === 'iPhone'", "${$.age}"],
+                ["true", "1"],
+              ],
+            },
+          },
+        },
+      },
+      {
+        id: "x",
+        type: "simple",
+      },
+      {
+        type: "feature",
+        id: "blah",
+        properties: {
+          firstName: "John",
+          lastName: "doe",
+          age: 26,
+          address: {
+            streetAddress: "naist street",
+            city: "Nara",
+            postalCode: "630-0192",
+          },
+          "phone:Numbers": [
+            {
+              type: "iPhone",
+              number: "0123-4567-8888",
+            },
+            {
+              type: "home",
+              number: "0123-4567-8910",
+            },
+          ],
+        },
+      },
+    ),
+  ).toEqual({
+    marker: {
+      pointColor: "#FF0000",
+      pointSize: 26,
+    },
+  });
+});


### PR DESCRIPTION
# Overview
This PR adds colon (`:`) as a reserved word in variableReplacer to bypass error produced by jsep while creating an AST and re:replace while accessing the properties for reals.

# Way to test
```{
  "3dtiles": {
    "color": {
      "expression": {
        "conditions": [
          [
            "${brid:class}==='桁橋'",
            "color('#F9FD4C')"
          ]
        ]
      }
    },
    "colorBlendMode": "highlight",
    "pbr": false,
    "shadows": "disabled"
  }
}
```
<img width="1444" alt="Screenshot 2024-02-29 at 11 31 54 AM" src="https://github.com/reearth/reearth/assets/42397980/78a3a8f3-2559-468b-80e2-7cdff908a3a0">

Dataset: https://assets.cms.plateau.reearth.io/assets/b2/372698-305c-4963-b9b2-b3acc6bf745a/14100_yokohama-shi_city_2023_citygml_1_op_brid_3dtiles_lod2/tileset.json