### PR TITLE
chore(web): add colon as reserved word in style evaluator

### DIFF
--- a/web/src/beta/lib/core/mantle/evaluator/simple/expression/runtime.ts
+++ b/web/src/beta/lib/core/mantle/evaluator/simple/expression/runtime.ts
@@ -76,6 +76,8 @@ function parseLiteral(ast: any): Node | Error {
   } else if (type === "string") {
     if (ast.value.indexOf("${") >= 0) {
       return new Node(ExpressionNodeType.VARIABLE_IN_STRING, ast.value);
+    } else if (ast.value.indexOf("$reearth_") >= 0) {
+      return new Node(ExpressionNodeType.LITERAL_STRING, restoreReservedWord(ast.value));
     }
     // } else if (rgbaMatcher.exec(ast.value) || rrggbbaaMatcher.exec(ast.value)) {
     //   const val = new Node(ExpressionNodeType.LITERAL_STRING, replaceBackslashes(ast.value));

--- a/web/src/beta/lib/core/mantle/evaluator/simple/expression/variableReplacer.ts
+++ b/web/src/beta/lib/core/mantle/evaluator/simple/expression/variableReplacer.ts
@@ -104,10 +104,11 @@ const RESERVED_WORDS: Record<string, string> = {
   "(": makeReservedWord("opened_parentheses"),
   ")": makeReservedWord("closed_parentheses"),
   "-": makeReservedWord("hyphen"),
+  ":": makeReservedWord("colon"),
 };
 
 const replaceReservedWord = (word: string) => {
-  const wordFiltered = word.replace(/-/g, RESERVED_WORDS["-"]);
+  const wordFiltered = word.replace(/-/g, RESERVED_WORDS["-"]).replace(/:/g, RESERVED_WORDS[":"]);
   if (!/(\]|\)|\})[^[.]+$/.test(wordFiltered)) {
     return wordFiltered;
   }

--- a/web/src/beta/lib/core/mantle/evaluator/simple/index.test.ts
+++ b/web/src/beta/lib/core/mantle/evaluator/simple/index.test.ts
@@ -601,3 +601,56 @@ test("Array equality with value", () => {
     },
   });
 });
+
+test("Conditions with JSONPath, strictly equal and JSONPath result, colon", async () => {
+  expect(
+    await evalLayerAppearances(
+      {
+        marker: {
+          pointColor: "#FF0000",
+          pointSize: {
+            expression: {
+              conditions: [
+                ["${$.phone:Numbers[:1].type} === 'iPhone'", "${$.age}"],
+                ["true", "1"],
+              ],
+            },
+          },
+        },
+      },
+      {
+        id: "x",
+        type: "simple",
+      },
+      {
+        type: "feature",
+        id: "blah",
+        properties: {
+          firstName: "John",
+          lastName: "doe",
+          age: 26,
+          address: {
+            streetAddress: "naist street",
+            city: "Nara",
+            postalCode: "630-0192",
+          },
+          "phone:Numbers": [
+            {
+              type: "iPhone",
+              number: "0123-4567-8888",
+            },
+            {
+              type: "home",
+              number: "0123-4567-8910",
+            },
+          ],
+        },
+      },
+    ),
+  ).toEqual({
+    marker: {
+      pointColor: "#FF0000",
+      pointSize: 26,
+    },
+  });
+});


### PR DESCRIPTION
# Overview
This PR adds colon as a reserved word in `reearth` core style evaluator to accomodate style conditions containing colon as the key name of properties by creating bypass by utilizing reserved words.
