### PR TITLE
chore(web): fix the zoomlevel for url

### DIFF
--- a/web/src/beta/lib/core/Map/types/index.ts
+++ b/web/src/beta/lib/core/Map/types/index.ts
@@ -352,6 +352,7 @@ export type SceneProperty = {
     tile_type?: string;
     tile_url?: string;
     tile_zoomLevel?: number[];
+    tile_zoomLevelForURL?: number[];
     tile_opacity?: number;
     heatmap?: boolean;
   }[];

--- a/web/src/beta/lib/core/engines/Cesium/core/Imagery.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/core/Imagery.tsx
@@ -84,6 +84,7 @@ export function useImageryProviders({
       url?: string;
       cesiumIonAccessToken?: string;
       heatmap?: boolean;
+      tile_zoomLevel?: number[];
     }) => ImageryProvider | null;
   };
 }): { providers: Providers; updated: boolean } {
@@ -93,6 +94,7 @@ export function useImageryProviders({
         url: t.tile_url,
         cesiumIonAccessToken: ciat,
         heatmap: t.heatmap,
+        tile_zoomLevel: t.tile_zoomLevel,
       }),
     [presets],
   );

--- a/web/src/beta/lib/core/engines/Cesium/core/Imagery.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/core/Imagery.tsx
@@ -24,6 +24,7 @@ export type Tile = {
   tile_type?: string;
   tile_opacity?: number;
   tile_zoomLevel?: number[];
+  tile_zoomLevelForURL?: number[];
   heatmap?: boolean;
 };
 
@@ -50,13 +51,13 @@ export default function ImageryLayers({ tiles, cesiumIonAccessToken }: Props) {
     <>
       {tiles
         ?.map(({ id, ...tile }) => ({ ...tile, id, provider: providers[id]?.[2] }))
-        .map(({ id, tile_opacity: opacity, tile_zoomLevel, tile_type, provider, heatmap }, i) =>
+        .map(({ id, tile_opacity: opacity, tile_zoomLevel, provider, heatmap }, i) =>
           provider ? (
             <ImageryLayer
               key={`${id}_${i}_${counter.current}`}
               imageryProvider={provider}
-              minimumTerrainLevel={tile_type !== "url" ? tile_zoomLevel?.[0] : undefined}
-              maximumTerrainLevel={tile_type !== "url" ? tile_zoomLevel?.[1] : undefined}
+              minimumTerrainLevel={tile_zoomLevel?.[0]}
+              maximumTerrainLevel={tile_zoomLevel?.[1]}
               alpha={opacity}
               index={i}
               colorToAlpha={heatmap ? Color.WHITE : undefined}
@@ -94,7 +95,7 @@ export function useImageryProviders({
         url: t.tile_url,
         cesiumIonAccessToken: ciat,
         heatmap: t.heatmap,
-        tile_zoomLevel: t.tile_zoomLevel,
+        tile_zoomLevel: t.tile_zoomLevelForURL,
       }),
     [presets],
   );

--- a/web/src/beta/lib/core/engines/Cesium/core/Imagery.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/core/Imagery.tsx
@@ -50,13 +50,13 @@ export default function ImageryLayers({ tiles, cesiumIonAccessToken }: Props) {
     <>
       {tiles
         ?.map(({ id, ...tile }) => ({ ...tile, id, provider: providers[id]?.[2] }))
-        .map(({ id, tile_opacity: opacity, tile_zoomLevel, provider, heatmap }, i) =>
+        .map(({ id, tile_opacity: opacity, tile_zoomLevel, tile_type, provider, heatmap }, i) =>
           provider ? (
             <ImageryLayer
               key={`${id}_${i}_${counter.current}`}
               imageryProvider={provider}
-              minimumTerrainLevel={tile_zoomLevel?.[0]}
-              maximumTerrainLevel={tile_zoomLevel?.[1]}
+              minimumTerrainLevel={tile_type !== "url" ? tile_zoomLevel?.[0] : undefined}
+              maximumTerrainLevel={tile_type !== "url" ? tile_zoomLevel?.[1] : undefined}
               alpha={opacity}
               index={i}
               colorToAlpha={heatmap ? Color.WHITE : undefined}

--- a/web/src/beta/lib/core/engines/Cesium/core/presets.ts
+++ b/web/src/beta/lib/core/engines/Cesium/core/presets.ts
@@ -57,11 +57,13 @@ export const tiles = {
     new OpenStreetMapImageryProvider({
       url: "https://cyberjapandata.gsi.go.jp/xyz/std/",
     }),
-  url: ({ url, heatmap } = {}) =>
+  url: ({ url, heatmap, tile_zoomLevel } = {}) =>
     url
       ? new UrlTemplateImageryProvider({
           url,
           tileDiscardPolicy: heatmap ? new DiscardEmptyTileImagePolicy() : undefined,
+          minimumLevel: tile_zoomLevel?.[0],
+          maximumLevel: tile_zoomLevel?.[1],
         })
       : null,
 } as {
@@ -69,6 +71,7 @@ export const tiles = {
     url?: string;
     cesiumIonAccessToken?: string;
     heatmap?: boolean;
+    tile_zoomLevel?: number[];
   }) => ImageryProvider | null;
 };
 


### PR DESCRIPTION
# Overview

To prevent unnecessary request for tile server, I need to specify the maximumLevel and the minimumLevel to UrlTemplateImageryProvider.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
