### PR TITLE
chore(server): add googleanalytics in cesium-beta manifest field

### DIFF
--- a/server/pkg/builtin/manifest.yml
+++ b/server/pkg/builtin/manifest.yml
@@ -275,6 +275,19 @@ extensions:
               ui: slider
               min: 0
               max: 10
+        - id: googleAnalytics
+          title: Google Analytics
+          description: Set your Google Analytics tracking ID and analyze how your published project is being viewed.
+          fields:
+            - id: enableGA
+              type: bool
+              title: Enable
+              defaultValue: false
+              description: Enable Google Analytics
+            - id: trackingId
+              type: string
+              title: Tracking ID
+              description: Paste your Google Analytics tracking ID here. This will be embedded in your published project.
   - id: cesium
     name: Cesium
     description: Select here to find scene settings in the right panel. This includes setting map tiles, atmospheric conditions, real lighting, and more.

--- a/server/pkg/builtin/manifest_ja.yml
+++ b/server/pkg/builtin/manifest_ja.yml
@@ -132,6 +132,16 @@ extensions:
             description: 有効にすると、カメラが地表の中に入るようになります。
           fov:
             title: 視野（FOV）
+      googleAnalytics:
+        title: Google Analytics
+        description: Google Analyticsを有効にすることで、公開ページがどのように閲覧されているかを分析することが可能です。
+        fields:
+          enableGA:
+            title: 有効
+            description: Google Analyticsを有効にします。
+          trackingCode:
+            title: トラッキングID
+            description: ここにGoogle AnalyticsのトラッキングIDを貼り付けることで、公開プロジェクトにこのコードが埋め込まれます。
   cesium:
     name: Cesium
     description: 右パネルでシーン全体の設定を変更することができます。タイル、大気、ライティングなどの設定が含まれています。


### PR DESCRIPTION
# Overview
This PR adds support for googleAnalytics in `cesium-beta` manifest.yml