### PR TITLE
feat(web,server): support multi-tenant login

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,5 +31,6 @@
   ],
   "[yaml]": {
     "editor.formatOnSave": false
-  }
+  },
+  "prettier.enable": false
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/joho/godotenv v1.4.0
 	github.com/jonas-p/go-shp v0.1.1
+	github.com/k0kubun/pp/v3 v3.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/labstack/echo/v4 v4.11.4

--- a/server/go.sum
+++ b/server/go.sum
@@ -423,6 +423,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
+github.com/k0kubun/pp/v3 v3.2.0 h1:h33hNTZ9nVFNP3u2Fsgz8JXiF5JINoZfFq4SvKJwNcs=
+github.com/k0kubun/pp/v3 v3.2.0/go.mod h1:ODtJQbQcIRfAD3N+theGCV1m/CBxweERz2dapdz1EwA=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=

--- a/server/gql/user.graphql
+++ b/server/gql/user.graphql
@@ -2,6 +2,7 @@ type User implements Node {
   id: ID!
   name: String!
   email: String!
+  host: String
 }
 
 type Me {
@@ -13,7 +14,7 @@ type Me {
   myTeamId: ID!
   auths: [String!]!
   teams: [Team!]!
-  myTeam: Team!
+  myTeam: Team
 }
 
 enum Theme {
@@ -51,7 +52,6 @@ input DeleteMeInput {
 
 # Payload
 
-
 type UpdateMePayload {
   me: Me!
 }
@@ -65,7 +65,7 @@ type DeleteMePayload {
   userId: ID!
 }
 
-extend type Query{
+extend type Query {
   me: Me
   searchUser(nameOrEmail: String!): User
 }

--- a/server/internal/adapter/gql/generated.go
+++ b/server/internal/adapter/gql/generated.go
@@ -1282,6 +1282,7 @@ type ComplexityRoot struct {
 
 	User struct {
 		Email func(childComplexity int) int
+		Host  func(childComplexity int) int
 		ID    func(childComplexity int) int
 		Name  func(childComplexity int) int
 	}
@@ -7637,6 +7638,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.User.Email(childComplexity), true
 
+	case "User.host":
+		if e.complexity.User.Host == nil {
+			break
+		}
+
+		return e.complexity.User.Host(childComplexity), true
+
 	case "User.id":
 		if e.complexity.User.ID == nil {
 			break
@@ -9916,6 +9924,7 @@ extend type Mutation {
   id: ID!
   name: String!
   email: String!
+  host: String
 }
 
 type Me {
@@ -9927,7 +9936,7 @@ type Me {
   myTeamId: ID!
   auths: [String!]!
   teams: [Team!]!
-  myTeam: Team!
+  myTeam: Team
 }
 
 enum Theme {
@@ -9965,7 +9974,6 @@ input DeleteMeInput {
 
 # Payload
 
-
 type UpdateMePayload {
   me: Me!
 }
@@ -9979,7 +9987,7 @@ type DeleteMePayload {
   userId: ID!
 }
 
-extend type Query{
+extend type Query {
   me: Me
   searchUser(nameOrEmail: String!): User
 }
@@ -9989,7 +9997,8 @@ extend type Mutation {
   updateMe(input: UpdateMeInput!): UpdateMePayload
   removeMyAuth(input: RemoveMyAuthInput!): UpdateMePayload
   deleteMe(input: DeleteMeInput!): DeleteMePayload
-}`, BuiltIn: false},
+}
+`, BuiltIn: false},
 	{Name: "../../../gql/was.graphql", Input: `type WidgetAlignSystem {
   inner: WidgetZone
   outer: WidgetZone
@@ -23678,14 +23687,11 @@ func (ec *executionContext) _Me_myTeam(ctx context.Context, field graphql.Collec
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(*gqlmodel.Team)
 	fc.Result = res
-	return ec.marshalNTeam2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐTeam(ctx, field.Selections, res)
+	return ec.marshalOTeam2ᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐTeam(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Me_myTeam(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -43319,6 +43325,8 @@ func (ec *executionContext) fieldContext_Query_searchUser(ctx context.Context, f
 				return ec.fieldContext_User_name(ctx, field)
 			case "email":
 				return ec.fieldContext_User_email(ctx, field)
+			case "host":
+				return ec.fieldContext_User_host(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -46721,6 +46729,8 @@ func (ec *executionContext) fieldContext_SignupPayload_user(ctx context.Context,
 				return ec.fieldContext_User_name(ctx, field)
 			case "email":
 				return ec.fieldContext_User_email(ctx, field)
+			case "host":
+				return ec.fieldContext_User_host(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -51241,6 +51251,8 @@ func (ec *executionContext) fieldContext_TeamMember_user(ctx context.Context, fi
 				return ec.fieldContext_User_name(ctx, field)
 			case "email":
 				return ec.fieldContext_User_email(ctx, field)
+			case "host":
+				return ec.fieldContext_User_host(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
 		},
@@ -53136,6 +53148,47 @@ func (ec *executionContext) _User_email(ctx context.Context, field graphql.Colle
 }
 
 func (ec *executionContext) fieldContext_User_email(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_host(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_host(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Host, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_host(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
@@ -64736,9 +64789,6 @@ func (ec *executionContext) _Me(ctx context.Context, sel ast.SelectionSet, obj *
 					}
 				}()
 				res = ec._Me_myTeam(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
 				return res
 			}
 
@@ -73143,6 +73193,8 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "host":
+			out.Values[i] = ec._User_host(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -76976,10 +77028,6 @@ func (ec *executionContext) marshalNTagItem2ᚖgithubᚗcomᚋreearthᚋreearth�
 		return graphql.Null
 	}
 	return ec._TagItem(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalNTeam2githubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐTeam(ctx context.Context, sel ast.SelectionSet, v gqlmodel.Team) graphql.Marshaler {
-	return ec._Team(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNTeam2ᚕᚖgithubᚗcomᚋreearthᚋreearthᚋserverᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐTeamᚄ(ctx context.Context, sel ast.SelectionSet, v []*gqlmodel.Team) graphql.Marshaler {

--- a/server/internal/adapter/gql/gqlmodel/convert_user.go
+++ b/server/internal/adapter/gql/gqlmodel/convert_user.go
@@ -3,6 +3,7 @@ package gqlmodel
 import (
 	"github.com/reearth/reearthx/account/accountdomain/user"
 	"github.com/reearth/reearthx/util"
+	"github.com/samber/lo"
 )
 
 func ToUser(u *user.User) *User {
@@ -14,6 +15,7 @@ func ToUser(u *user.User) *User {
 		ID:    IDFrom(u.ID()),
 		Name:  u.Name(),
 		Email: u.Email(),
+		Host:  lo.EmptyableToPtr(u.Host()),
 	}
 }
 

--- a/server/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/internal/adapter/gql/gqlmodel/models_gen.go
@@ -756,7 +756,7 @@ type Me struct {
 	MyTeamID ID           `json:"myTeamId"`
 	Auths    []string     `json:"auths"`
 	Teams    []*Team      `json:"teams"`
-	MyTeam   *Team        `json:"myTeam"`
+	MyTeam   *Team        `json:"myTeam,omitempty"`
 }
 
 type MergedInfobox struct {
@@ -1880,9 +1880,10 @@ type UploadPluginPayload struct {
 }
 
 type User struct {
-	ID    ID     `json:"id"`
-	Name  string `json:"name"`
-	Email string `json:"email"`
+	ID    ID      `json:"id"`
+	Name  string  `json:"name"`
+	Email string  `json:"email"`
+	Host  *string `json:"host,omitempty"`
 }
 
 func (User) IsNode()        {}

--- a/server/internal/app/config/auth.go
+++ b/server/internal/app/config/auth.go
@@ -10,12 +10,12 @@ import (
 )
 
 type AuthConfig struct {
-	ISS      string
-	AUD      []string
-	ALG      *string
-	TTL      *int
-	ClientID *string
-	JWKSURI  *string
+	ISS      string   `pp:",omitempty"`
+	AUD      []string `pp:",omitempty"`
+	ALG      *string  `pp:",omitempty"`
+	TTL      *int     `pp:",omitempty"`
+	ClientID *string  `pp:",omitempty"`
+	JWKSURI  *string  `pp:",omitempty"`
 }
 
 func (a AuthConfig) JWTProvider() appx.JWTProvider {
@@ -56,11 +56,11 @@ func (a AuthConfigs) JWTProviders() []appx.JWTProvider {
 }
 
 type Auth0Config struct {
-	Domain       string
-	Audience     string
-	ClientID     string
-	ClientSecret string
-	WebClientID  string
+	Domain       string `pp:",omitempty"`
+	Audience     string `pp:",omitempty"`
+	ClientID     string `pp:",omitempty"`
+	ClientSecret string `pp:",omitempty"`
+	WebClientID  string `pp:",omitempty"`
 }
 
 func (c Auth0Config) AuthConfigForWeb() *AuthConfig {
@@ -106,9 +106,9 @@ func (c Auth0Config) Configs() (res AuthConfigs) {
 }
 
 type CognitoConfig struct {
-	UserPoolID string
-	Region     string
-	ClientID   string
+	UserPoolID string `pp:",omitempty"`
+	Region     string `pp:",omitempty"`
+	ClientID   string `pp:",omitempty"`
 }
 
 func (c CognitoConfig) Configs() AuthConfigs {

--- a/server/internal/app/config/auth_server.go
+++ b/server/internal/app/config/auth_server.go
@@ -10,13 +10,13 @@ import (
 const AuthServerDefaultClientID = "reearth-authsrv-client-default"
 
 type AuthSrvConfig struct {
-	Dev      bool
-	Disabled bool
-	Issuer   string
-	Domain   string
-	UIDomain string
-	Key      string
-	DN       *AuthSrvDNConfig
+	Dev      bool             `pp:",omitempty"`
+	Disabled bool             `pp:",omitempty"`
+	Issuer   string           `pp:",omitempty"`
+	Domain   string           `pp:",omitempty"`
+	UIDomain string           `pp:",omitempty"`
+	Key      string           `pp:",omitempty"`
+	DN       *AuthSrvDNConfig `pp:",omitempty"`
 }
 
 func (c AuthSrvConfig) AuthConfig(debug bool, host string) *AuthConfig {
@@ -44,14 +44,14 @@ func (c AuthSrvConfig) AuthConfig(debug bool, host string) *AuthConfig {
 }
 
 type AuthSrvDNConfig struct {
-	CN         string
-	O          []string
-	OU         []string
-	C          []string
-	L          []string
-	ST         []string
-	Street     []string
-	PostalCode []string
+	CN         string   `pp:",omitempty"`
+	O          []string `pp:",omitempty"`
+	OU         []string `pp:",omitempty"`
+	C          []string `pp:",omitempty"`
+	L          []string `pp:",omitempty"`
+	ST         []string `pp:",omitempty"`
+	Street     []string `pp:",omitempty"`
+	PostalCode []string `pp:",omitempty"`
 }
 
 func (a *AuthSrvDNConfig) AuthServerDNConfig() *authserver.DNConfig {

--- a/server/internal/app/config/file.go
+++ b/server/internal/app/config/file.go
@@ -1,8 +1,8 @@
 package config
 
 type GCSConfig struct {
-	BucketName              string
-	PublicationCacheControl string
+	BucketName              string `pp:",omitempty"`
+	PublicationCacheControl string `pp:",omitempty"`
 }
 
 func (g GCSConfig) IsConfigured() bool {

--- a/server/internal/app/config/marketplace.go
+++ b/server/internal/app/config/marketplace.go
@@ -8,17 +8,17 @@ import (
 )
 
 type MarketplaceConfig struct {
-	Endpoint string
-	Secret   string
-	OAuth    *OAuthClientCredentialsConfig
+	Endpoint string                        `pp:",omitempty"`
+	Secret   string                        `pp:",omitempty"`
+	OAuth    *OAuthClientCredentialsConfig `pp:",omitempty"`
 }
 
 type OAuthClientCredentialsConfig struct {
-	ClientID     string
-	ClientSecret string
-	TokenURL     string
-	Scopes       []string
-	Audience     []string
+	ClientID     string   `pp:",omitempty"`
+	ClientSecret string   `pp:",omitempty"`
+	TokenURL     string   `pp:",omitempty"`
+	Scopes       []string `pp:",omitempty"`
+	Audience     []string `pp:",omitempty"`
 }
 
 func (c *OAuthClientCredentialsConfig) Config() *clientcredentials.Config {

--- a/server/internal/app/config/policy.go
+++ b/server/internal/app/config/policy.go
@@ -3,5 +3,5 @@ package config
 import "github.com/reearth/reearth/server/pkg/policy"
 
 type PolicyConfig struct {
-	Default *policy.ID
+	Default *policy.ID `pp:",omitempty"`
 }

--- a/server/internal/app/config/published.go
+++ b/server/internal/app/config/published.go
@@ -3,6 +3,6 @@ package config
 import "net/url"
 
 type PublishedConfig struct {
-	IndexURL *url.URL
-	Host     string
+	IndexURL *url.URL `pp:",omitempty"`
+	Host     string   `pp:",omitempty"`
 }

--- a/server/internal/app/config/web.go
+++ b/server/internal/app/config/web.go
@@ -3,7 +3,7 @@ package config
 import "encoding/json"
 
 type JSON struct {
-	Data any
+	Data any `pp:",omitempty"`
 }
 
 func (j *JSON) Decode(value string) error {

--- a/server/internal/infrastructure/mongo/scene.go
+++ b/server/internal/infrastructure/mongo/scene.go
@@ -66,6 +66,10 @@ func (r *Scene) FindByProject(ctx context.Context, id id.ProjectID) (*scene.Scen
 }
 
 func (r *Scene) FindByWorkspace(ctx context.Context, workspaces ...accountdomain.WorkspaceID) (scene.List, error) {
+	if len(workspaces) == 0 {
+		return nil, nil
+	}
+
 	workspaces2 := accountdomain.WorkspaceIDList(workspaces)
 	if r.f.Readable != nil {
 		workspaces2 = workspaces2.Intersect(r.f.Readable)

--- a/web/src/classic/components/molecules/Dashboard/QuickStart.tsx
+++ b/web/src/classic/components/molecules/Dashboard/QuickStart.tsx
@@ -26,8 +26,9 @@ export interface Props {
     imageUrl: string;
     projectType: ProjectType;
   }) => Promise<void>;
-  toggleAssetModal?: () => void;
+  onProjectCreateClick?: () => boolean;
   onAssetSelect?: (asset?: string) => void;
+  toggleAssetModal?: () => void;
 }
 
 const QuickStart: React.FC<Props> = ({
@@ -36,8 +37,9 @@ const QuickStart: React.FC<Props> = ({
   selectedAsset,
   onWorkspaceCreate,
   onProjectCreate,
-  toggleAssetModal,
+  onProjectCreateClick,
   onAssetSelect,
+  toggleAssetModal,
 }) => {
   const documentationUrl = window.REEARTH_CONFIG?.documentationUrl;
   const t = useT();
@@ -53,13 +55,15 @@ const QuickStart: React.FC<Props> = ({
   } = useMeQuery();
 
   const handleCreateProjectClick = useCallback(() => {
+    if (onProjectCreateClick && !onProjectCreateClick()) return;
+
     if (
       window.REEARTH_CONFIG?.developerMode ||
       window.REEARTH_CONFIG?.earlyAccessAdmins?.includes(email)
     )
       setPrjTypeSelectOpen(true);
     else setPrjCreateOpen(true);
-  }, [email]);
+  }, [email, onProjectCreateClick]);
 
   const handleProjModalClose = useCallback(() => {
     setPrjCreateOpen(false);
@@ -67,9 +71,11 @@ const QuickStart: React.FC<Props> = ({
   }, [onAssetSelect]);
 
   const handlePrjTypeSelectModalClose = useCallback(() => {
+    if (onProjectCreateClick && !onProjectCreateClick()) return;
+
     setPrjTypeSelectOpen(false);
     setPrjCreateOpen(true);
-  }, []);
+  }, [onProjectCreateClick]);
 
   const handleProjectTypeSelect = (type: ProjectType) => {
     setPrjectType(type);

--- a/web/src/classic/components/molecules/Settings/WorkspaceList/WorkspaceCell/index.tsx
+++ b/web/src/classic/components/molecules/Settings/WorkspaceList/WorkspaceCell/index.tsx
@@ -7,9 +7,12 @@ import { metricsSizes } from "@reearth/classic/theme";
 import { useT } from "@reearth/services/i18n";
 import { styled, useTheme } from "@reearth/services/theme";
 
-import { Workspace as WorkspaceType } from "../WorkspaceList";
-
-export type Workspace = WorkspaceType;
+export type Workspace = {
+  id: string;
+  name: string;
+  personal: boolean;
+  members: { userId: string; user?: { name: string } }[];
+};
 
 export type Props = {
   className?: string;

--- a/web/src/classic/components/molecules/Settings/WorkspaceList/WorkspaceList/index.tsx
+++ b/web/src/classic/components/molecules/Settings/WorkspaceList/WorkspaceList/index.tsx
@@ -2,12 +2,13 @@ import React, { useMemo } from "react";
 
 import Button from "@reearth/classic/components/atoms/Button";
 import Text from "@reearth/classic/components/atoms/Text";
-import WorkspaceCell from "@reearth/classic/components/molecules/Settings/WorkspaceList/WorkspaceCell";
-import { Team as WorkspaceType } from "@reearth/classic/gql/graphql-client-api";
+import WorkspaceCell, {
+  type Workspace,
+} from "@reearth/classic/components/molecules/Settings/WorkspaceList/WorkspaceCell";
 import { useT } from "@reearth/services/i18n";
 import { styled, useTheme } from "@reearth/services/theme";
 
-export type Workspace = WorkspaceType;
+export type { Workspace } from "@reearth/classic/components/molecules/Settings/WorkspaceList/WorkspaceCell";
 
 export type Props = {
   title?: string;

--- a/web/src/classic/components/organisms/Authentication/RootPage/hooks.ts
+++ b/web/src/classic/components/organisms/Authentication/RootPage/hooks.ts
@@ -62,10 +62,10 @@ export default () => {
     } else if (!isAuthenticated && !isLoading) {
       login();
     } else {
-      if (currentWorkspace || !data || !workspaceId) return;
+      if (!data?.me) return;
       setCurrentUserId(data?.me?.id);
       setCurrentWorkspace(data.me?.myTeam ?? undefined);
-      navigate(`/dashboard/${workspaceId || ""}`);
+      navigate(`/dashboard${workspaceId ? "/" + workspaceId : ""}`);
     }
   }, [
     isAuthenticated,

--- a/web/src/classic/components/organisms/Authentication/RootPage/hooks.ts
+++ b/web/src/classic/components/organisms/Authentication/RootPage/hooks.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useGetTeamsQuery } from "@reearth/classic/gql";
@@ -24,9 +24,7 @@ export default () => {
     setCurrentUserId(data?.me?.id);
   }
 
-  const workspaceId = useMemo(() => {
-    return currentWorkspace?.id || data?.me?.myTeam.id;
-  }, [currentWorkspace?.id, data?.me?.myTeam.id]);
+  const workspaceId = currentWorkspace?.id || data?.me?.myTeam?.id;
 
   const verifySignup = useCallback(
     async (token: string) => {
@@ -66,8 +64,8 @@ export default () => {
     } else {
       if (currentWorkspace || !data || !workspaceId) return;
       setCurrentUserId(data?.me?.id);
-      setCurrentWorkspace(data.me?.myTeam);
-      navigate(`/dashboard/${workspaceId}`);
+      setCurrentWorkspace(data.me?.myTeam ?? undefined);
+      navigate(`/dashboard/${workspaceId || ""}`);
     }
   }, [
     isAuthenticated,

--- a/web/src/classic/components/organisms/Dashboard/hooks.ts
+++ b/web/src/classic/components/organisms/Dashboard/hooks.ts
@@ -173,6 +173,10 @@ export default (workspaceId?: string) => {
   const { useCreateStory } = useStorytellingFetcher();
   const { useCreateStoryPage } = useStorytellingFetcher();
 
+  const handleProjectCreateClick = useCallback((): boolean => {
+    return !!workspaceId;
+  }, [workspaceId]);
+
   const handleProjectCreate = useCallback(
     async (data: {
       name: string;
@@ -290,6 +294,7 @@ export default (workspaceId?: string) => {
     selectedAsset,
     assetModalOpened,
     handleProjectCreate,
+    handleProjectCreateClick,
     handleWorkspaceCreate,
     handleWorkspaceChange,
     handleModalOpen,

--- a/web/src/classic/components/organisms/Dashboard/hooks.ts
+++ b/web/src/classic/components/organisms/Dashboard/hooks.ts
@@ -54,7 +54,7 @@ export default (workspaceId?: string) => {
 
   const workspaces = data?.me?.teams;
   const workspace = workspaces?.find(workspace => workspace.id === workspaceId);
-  const personal = workspaceId === data?.me?.myTeam.id;
+  const personal = !!workspaceId && workspaceId === data?.me?.myTeam?.id;
   const gqlCache = useApolloClient().cache;
 
   useEffect(() => {
@@ -167,7 +167,9 @@ export default (workspaceId?: string) => {
   }, [projectData?.projects.pageInfo, fetchMore, hasMoreProjects]);
 
   const [createNewProject] = useCreateProjectMutation();
-  const [createScene] = useCreateSceneMutation({ refetchQueries: ["GetProjects"] });
+  const [createScene] = useCreateSceneMutation({
+    refetchQueries: ["GetProjects"],
+  });
   const { useCreateStory } = useStorytellingFetcher();
   const { useCreateStoryPage } = useStorytellingFetcher();
 

--- a/web/src/classic/components/organisms/Dashboard/index.tsx
+++ b/web/src/classic/components/organisms/Dashboard/index.tsx
@@ -29,6 +29,7 @@ const Dashboard: React.FC<Props> = ({ workspaceId }) => {
     selectedAsset,
     assetModalOpened,
     handleProjectCreate,
+    handleProjectCreateClick,
     handleWorkspaceCreate,
     handleWorkspaceChange,
     handleModalOpen,
@@ -63,6 +64,7 @@ const Dashboard: React.FC<Props> = ({ workspaceId }) => {
         selectedAsset={selectedAsset}
         onWorkspaceCreate={handleWorkspaceCreate}
         onProjectCreate={handleProjectCreate}
+        onProjectCreateClick={handleProjectCreateClick}
         onAssetSelect={handleAssetSelect}
         toggleAssetModal={handleAssetModalToggle}
         assetModal={

--- a/web/src/classic/components/pages/Authentication/hooks.ts
+++ b/web/src/classic/components/pages/Authentication/hooks.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { useGetTeamsQuery } from "@reearth/classic/gql";
@@ -26,9 +26,7 @@ export default () => {
     setCurrentUserId(data?.me?.id);
   }
 
-  const workspaceId = useMemo(() => {
-    return currentWorkspace?.id || data?.me?.myTeam.id;
-  }, [currentWorkspace?.id, data?.me?.myTeam.id]);
+  const workspaceId = currentWorkspace?.id || data?.me?.myTeam?.id;
 
   useEffect(() => {
     if (location.pathname === "/login" && !new URLSearchParams(window.location.search).has("id"))
@@ -38,7 +36,7 @@ export default () => {
   useEffect(() => {
     if (!isAuthenticated || currentWorkspace || !data || !workspaceId) return;
     setCurrentUserId(data?.me?.id);
-    setCurrentWorkspace(data.me?.myTeam);
+    setCurrentWorkspace(data.me?.myTeam ?? undefined);
   }, [
     isAuthenticated,
     navigate,

--- a/web/src/classic/gql/graphql-client-api.tsx
+++ b/web/src/classic/gql/graphql-client-api.tsx
@@ -746,7 +746,7 @@ export type Me = {
   email: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   lang: Scalars['Lang']['output'];
-  myTeam: Team;
+  myTeam?: Maybe<Team>;
   myTeamId: Scalars['ID']['output'];
   name: Scalars['String']['output'];
   teams: Array<Team>;
@@ -1661,6 +1661,7 @@ export type Project = Node & {
   coreSupport: Scalars['Boolean']['output'];
   createdAt: Scalars['DateTime']['output'];
   description: Scalars['String']['output'];
+  enableGa: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
   imageUrl?: Maybe<Scalars['URL']['output']>;
   isArchived: Scalars['Boolean']['output'];
@@ -1675,6 +1676,7 @@ export type Project = Node & {
   scene?: Maybe<Scene>;
   team?: Maybe<Team>;
   teamId: Scalars['ID']['output'];
+  trackingId: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];
   visualizer: Visualizer;
 };
@@ -2541,6 +2543,7 @@ export type UpdateProjectInput = {
   deleteImageUrl?: InputMaybe<Scalars['Boolean']['input']>;
   deletePublicImage?: InputMaybe<Scalars['Boolean']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
+  enableGA?: InputMaybe<Scalars['Boolean']['input']>;
   imageUrl?: InputMaybe<Scalars['URL']['input']>;
   isBasicAuthActive?: InputMaybe<Scalars['Boolean']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
@@ -2549,6 +2552,7 @@ export type UpdateProjectInput = {
   publicImage?: InputMaybe<Scalars['String']['input']>;
   publicNoIndex?: InputMaybe<Scalars['Boolean']['input']>;
   publicTitle?: InputMaybe<Scalars['String']['input']>;
+  trackingId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdatePropertyItemInput = {
@@ -2701,6 +2705,7 @@ export type UploadPluginPayload = {
 export type User = Node & {
   __typename?: 'User';
   email: Scalars['String']['output'];
+  host?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
 };
@@ -3675,12 +3680,12 @@ export type GetUserBySearchQuery = { __typename?: 'Query', searchUser?: { __type
 export type GetMeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetMeQuery = { __typename?: 'Query', me?: { __typename?: 'Me', id: string, name: string, email: string, auths: Array<string>, myTeam: { __typename?: 'Team', id: string, name: string, policyId?: string | null, projects: { __typename?: 'ProjectConnection', nodes: Array<{ __typename?: 'Project', id: string, publishmentStatus: PublishmentStatus, isArchived: boolean, name: string, imageUrl?: string | null, description: string, visualizer: Visualizer, scene?: { __typename?: 'Scene', id: string } | null } | null> }, policy?: { __typename?: 'Policy', id: string, name: string, projectCount?: number | null, memberCount?: number | null, publishedProjectCount?: number | null, layerCount?: number | null, assetStorageSize?: number | null, datasetSchemaCount?: number | null, datasetCount?: number | null } | null }, teams: Array<{ __typename?: 'Team', id: string, name: string, policyId?: string | null, members: Array<{ __typename?: 'TeamMember', userId: string, role: Role, user?: { __typename?: 'User', id: string, name: string, email: string } | null }>, policy?: { __typename?: 'Policy', id: string, name: string, projectCount?: number | null, memberCount?: number | null, publishedProjectCount?: number | null, layerCount?: number | null, assetStorageSize?: number | null, datasetSchemaCount?: number | null, datasetCount?: number | null } | null, projects: { __typename?: 'ProjectConnection', nodes: Array<{ __typename?: 'Project', id: string, publishmentStatus: PublishmentStatus, isArchived: boolean, name: string, imageUrl?: string | null, description: string, visualizer: Visualizer, scene?: { __typename?: 'Scene', id: string } | null } | null> } }> } | null };
+export type GetMeQuery = { __typename?: 'Query', me?: { __typename?: 'Me', id: string, name: string, email: string, auths: Array<string>, myTeam?: { __typename?: 'Team', id: string, name: string, policyId?: string | null, projects: { __typename?: 'ProjectConnection', nodes: Array<{ __typename?: 'Project', id: string, publishmentStatus: PublishmentStatus, isArchived: boolean, name: string, imageUrl?: string | null, description: string, visualizer: Visualizer, scene?: { __typename?: 'Scene', id: string } | null } | null> }, policy?: { __typename?: 'Policy', id: string, name: string, projectCount?: number | null, memberCount?: number | null, publishedProjectCount?: number | null, layerCount?: number | null, assetStorageSize?: number | null, datasetSchemaCount?: number | null, datasetCount?: number | null } | null } | null, teams: Array<{ __typename?: 'Team', id: string, name: string, policyId?: string | null, members: Array<{ __typename?: 'TeamMember', userId: string, role: Role, user?: { __typename?: 'User', id: string, name: string, email: string } | null }>, policy?: { __typename?: 'Policy', id: string, name: string, projectCount?: number | null, memberCount?: number | null, publishedProjectCount?: number | null, layerCount?: number | null, assetStorageSize?: number | null, datasetSchemaCount?: number | null, datasetCount?: number | null } | null, projects: { __typename?: 'ProjectConnection', nodes: Array<{ __typename?: 'Project', id: string, publishmentStatus: PublishmentStatus, isArchived: boolean, name: string, imageUrl?: string | null, description: string, visualizer: Visualizer, scene?: { __typename?: 'Scene', id: string } | null } | null> } }> } | null };
 
 export type GetProfileQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetProfileQuery = { __typename?: 'Query', me?: { __typename?: 'Me', id: string, name: string, email: string, lang: string, theme: Theme, auths: Array<string>, myTeam: { __typename?: 'Team', id: string, name: string } } | null };
+export type GetProfileQuery = { __typename?: 'Query', me?: { __typename?: 'Me', id: string, name: string, email: string, lang: string, theme: Theme, auths: Array<string>, myTeam?: { __typename?: 'Team', id: string, name: string } | null } | null };
 
 export type GetLanguageQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -3702,7 +3707,7 @@ export type UpdateMeMutationVariables = Exact<{
 }>;
 
 
-export type UpdateMeMutation = { __typename?: 'Mutation', updateMe?: { __typename?: 'UpdateMePayload', me: { __typename?: 'Me', id: string, name: string, email: string, lang: string, theme: Theme, myTeam: { __typename?: 'Team', id: string, name: string } } } | null };
+export type UpdateMeMutation = { __typename?: 'Mutation', updateMe?: { __typename?: 'UpdateMePayload', me: { __typename?: 'Me', id: string, name: string, email: string, lang: string, theme: Theme, myTeam?: { __typename?: 'Team', id: string, name: string } | null } } | null };
 
 export type DeleteMeMutationVariables = Exact<{
   userId: Scalars['ID']['input'];
@@ -3775,7 +3780,7 @@ export type TeamFragment = { __typename?: 'Team', id: string, name: string, pers
 export type GetTeamsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetTeamsQuery = { __typename?: 'Query', me?: { __typename?: 'Me', id: string, name: string, myTeam: { __typename?: 'Team', id: string, name: string, personal: boolean, policyId?: string | null, members: Array<{ __typename?: 'TeamMember', userId: string, role: Role, user?: { __typename?: 'User', id: string, name: string, email: string } | null }>, policy?: { __typename?: 'Policy', id: string, name: string, projectCount?: number | null, memberCount?: number | null, publishedProjectCount?: number | null, layerCount?: number | null, assetStorageSize?: number | null, datasetSchemaCount?: number | null, datasetCount?: number | null } | null }, teams: Array<{ __typename?: 'Team', id: string, name: string, personal: boolean, policyId?: string | null, members: Array<{ __typename?: 'TeamMember', userId: string, role: Role, user?: { __typename?: 'User', id: string, name: string, email: string } | null }>, policy?: { __typename?: 'Policy', id: string, name: string, projectCount?: number | null, memberCount?: number | null, publishedProjectCount?: number | null, layerCount?: number | null, assetStorageSize?: number | null, datasetSchemaCount?: number | null, datasetCount?: number | null } | null }> } | null };
+export type GetTeamsQuery = { __typename?: 'Query', me?: { __typename?: 'Me', id: string, name: string, myTeam?: { __typename?: 'Team', id: string, name: string, personal: boolean, policyId?: string | null, members: Array<{ __typename?: 'TeamMember', userId: string, role: Role, user?: { __typename?: 'User', id: string, name: string, email: string } | null }>, policy?: { __typename?: 'Policy', id: string, name: string, projectCount?: number | null, memberCount?: number | null, publishedProjectCount?: number | null, layerCount?: number | null, assetStorageSize?: number | null, datasetSchemaCount?: number | null, datasetCount?: number | null } | null } | null, teams: Array<{ __typename?: 'Team', id: string, name: string, personal: boolean, policyId?: string | null, members: Array<{ __typename?: 'TeamMember', userId: string, role: Role, user?: { __typename?: 'User', id: string, name: string, email: string } | null }>, policy?: { __typename?: 'Policy', id: string, name: string, projectCount?: number | null, memberCount?: number | null, publishedProjectCount?: number | null, layerCount?: number | null, assetStorageSize?: number | null, datasetSchemaCount?: number | null, datasetCount?: number | null } | null }> } | null };
 
 export type CreateTeamMutationVariables = Exact<{
   name: Scalars['String']['input'];

--- a/web/src/classic/gql/graphql.schema.json
+++ b/web/src/classic/gql/graphql.schema.json
@@ -6675,13 +6675,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Team",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "Team",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -12950,6 +12946,22 @@
             "deprecationReason": null
           },
           {
+            "name": "enableGa",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "args": [],
@@ -13151,6 +13163,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "trackingId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -20718,6 +20746,18 @@
             "deprecationReason": null
           },
           {
+            "name": "enableGA",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "imageUrl",
             "description": null,
             "type": {
@@ -20807,6 +20847,18 @@
           },
           {
             "name": "publicTitle",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "trackingId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -22209,6 +22261,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "host",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/web/src/services/auth/auth0Auth.ts
+++ b/web/src/services/auth/auth0Auth.ts
@@ -1,6 +1,6 @@
 import { useAuth0 } from "@auth0/auth0-react";
 
-import { e2eAccessToken } from "@reearth/services/config";
+import { e2eAccessToken, logOutFromTenant } from "@reearth/services/config";
 
 import type { AuthHook } from "./authHook";
 
@@ -15,14 +15,19 @@ export const useAuth0Auth = (): AuthHook => {
     isLoading,
     error: error?.message ?? null,
     getAccessToken: () => getAccessTokenSilently(),
-    login: () => loginWithRedirect(),
-    logout: () =>
-      logout({
+    login: () => {
+      logOutFromTenant();
+      return loginWithRedirect();
+    },
+    logout: () => {
+      logOutFromTenant();
+      return logout({
         logoutParams: {
           returnTo: error
             ? `${window.location.origin}?${errorKey}=${encodeURIComponent(error?.message)}`
             : window.location.origin,
         },
-      }),
+      });
+    },
   };
 };

--- a/web/src/services/auth/authProvider.tsx
+++ b/web/src/services/auth/authProvider.tsx
@@ -1,5 +1,7 @@
 import { Auth0Provider } from "@auth0/auth0-react";
-import React, { createContext, ReactNode, Fragment } from "react";
+import React, { createContext, ReactNode, useState } from "react";
+
+import { getAuthInfo, getSignInCallbackUrl } from "../config/authInfo";
 
 import type { AuthHook } from "./authHook";
 import { useAuth0Auth } from "./authOAuth";
@@ -18,13 +20,14 @@ const CognitoWrapper = ({ children }: { children: ReactNode }) => {
 };
 
 export const AuthProvider: React.FC<{ children?: ReactNode }> = ({ children }) => {
-  const authProvider = window.REEARTH_CONFIG?.authProvider;
+  const [authInfo] = useState(() => getAuthInfo());
 
-  if (authProvider === "auth0") {
-    const domain = window.REEARTH_CONFIG?.auth0Domain;
-    const clientId = window.REEARTH_CONFIG?.auth0ClientId;
-    const audience = window.REEARTH_CONFIG?.auth0Audience;
+  if (authInfo?.authProvider === "auth0") {
+    const domain = authInfo.auth0Domain;
+    const clientId = authInfo.auth0ClientId;
+    const audience = authInfo.auth0Audience;
 
+    console.log("auth0", authInfo);
     return domain && clientId ? (
       <Auth0Provider
         domain={domain}
@@ -32,7 +35,7 @@ export const AuthProvider: React.FC<{ children?: ReactNode }> = ({ children }) =
         authorizationParams={{
           audience: audience,
           scope: "openid profile email offline_access",
-          redirect_uri: window.location.origin,
+          redirect_uri: getSignInCallbackUrl(),
         }}
         useRefreshTokens
         useRefreshTokensFallback
@@ -42,10 +45,10 @@ export const AuthProvider: React.FC<{ children?: ReactNode }> = ({ children }) =
     ) : null;
   }
 
-  if (authProvider === "cognito") {
+  if (authInfo?.authProvider === "cognito") {
     // No specific provider needed for Cognito/AWS Amplify
     return <CognitoWrapper>{children}</CognitoWrapper>;
   }
 
-  return <Fragment>{children}</Fragment>; // or some default fallback
+  return null;
 };

--- a/web/src/services/auth/authProvider.tsx
+++ b/web/src/services/auth/authProvider.tsx
@@ -1,7 +1,7 @@
 import { Auth0Provider } from "@auth0/auth0-react";
 import React, { createContext, ReactNode, useState } from "react";
 
-import { getAuthInfo, getSignInCallbackUrl } from "../config";
+import { getAuthInfo, getSignInCallbackUrl, logInToTenant } from "@reearth/services/config";
 
 import { useAuth0Auth } from "./auth0Auth";
 import type { AuthHook } from "./authHook";
@@ -20,7 +20,10 @@ const CognitoWrapper = ({ children }: { children: ReactNode }) => {
 };
 
 export const AuthProvider: React.FC<{ children?: ReactNode }> = ({ children }) => {
-  const [authInfo] = useState(() => getAuthInfo());
+  const [authInfo] = useState(() => {
+    logInToTenant(); // note that it includes side effect
+    return getAuthInfo();
+  });
 
   if (authInfo?.authProvider === "auth0") {
     const domain = authInfo.auth0Domain;

--- a/web/src/services/auth/authProvider.tsx
+++ b/web/src/services/auth/authProvider.tsx
@@ -1,7 +1,7 @@
 import { Auth0Provider } from "@auth0/auth0-react";
 import React, { createContext, ReactNode, useState } from "react";
 
-import { getAuthInfo, getSignInCallbackUrl } from "../config/authInfo";
+import { getAuthInfo, getSignInCallbackUrl } from "../config";
 
 import type { AuthHook } from "./authHook";
 import { useAuth0Auth } from "./authOAuth";

--- a/web/src/services/auth/authProvider.tsx
+++ b/web/src/services/auth/authProvider.tsx
@@ -3,8 +3,8 @@ import React, { createContext, ReactNode, useState } from "react";
 
 import { getAuthInfo, getSignInCallbackUrl } from "../config";
 
+import { useAuth0Auth } from "./auth0Auth";
 import type { AuthHook } from "./authHook";
-import { useAuth0Auth } from "./authOAuth";
 import { useCognitoAuth } from "./cognitoAuth";
 
 export const AuthContext = createContext<AuthHook | null>(null);
@@ -27,7 +27,6 @@ export const AuthProvider: React.FC<{ children?: ReactNode }> = ({ children }) =
     const clientId = authInfo.auth0ClientId;
     const audience = authInfo.auth0Audience;
 
-    console.log("auth0", authInfo);
     return domain && clientId ? (
       <Auth0Provider
         domain={domain}

--- a/web/src/services/auth/cognitoAuth.ts
+++ b/web/src/services/auth/cognitoAuth.ts
@@ -1,6 +1,8 @@
 import { Auth } from "@aws-amplify/auth";
 import { useState, useEffect } from "react";
 
+import { logOutFromTenant } from "@reearth/services/config";
+
 import type { AuthHook } from "./authHook";
 
 export const useCognitoAuth = (): AuthHook => {
@@ -32,10 +34,12 @@ export const useCognitoAuth = (): AuthHook => {
   };
 
   const login = () => {
+    logOutFromTenant();
     Auth.federatedSignIn();
   };
 
   const logout = async () => {
+    logOutFromTenant();
     try {
       await Auth.signOut();
       setUser(null);

--- a/web/src/services/auth/useAuth.ts
+++ b/web/src/services/auth/useAuth.ts
@@ -1,7 +1,5 @@
 import { useContext, useEffect, useState } from "react";
 
-import { logInToTenant } from "@reearth/services/config";
-
 import { useAuth0Auth } from "./auth0Auth";
 import { AuthContext } from "./authProvider";
 
@@ -42,7 +40,6 @@ export function useCleanUrl(): [string | undefined, boolean] {
 
     history.replaceState(null, document.title, url);
 
-    logInToTenant();
     setDone(true);
   }, [isAuthenticated, isLoading]);
 

--- a/web/src/services/auth/useAuth.ts
+++ b/web/src/services/auth/useAuth.ts
@@ -1,6 +1,8 @@
 import { useContext, useEffect, useState } from "react";
 
-import { useAuth0Auth } from "./authOAuth";
+import { logInToTenant } from "@reearth/services/config";
+
+import { useAuth0Auth } from "./auth0Auth";
 import { AuthContext } from "./authProvider";
 
 export const errorKey = "reeartherror";
@@ -39,6 +41,8 @@ export function useCleanUrl(): [string | undefined, boolean] {
     const url = `${window.location.pathname}${queries ? "?" : ""}${queries}`;
 
     history.replaceState(null, document.title, url);
+
+    logInToTenant();
     setDone(true);
   }, [isAuthenticated, isLoading]);
 

--- a/web/src/services/config/authInfo.ts
+++ b/web/src/services/config/authInfo.ts
@@ -27,7 +27,8 @@ export function getSignInCallbackUrl() {
 
 export function logInToTenant() {
   const tenantName = getLogginInTenantName();
-  if (tenantName) {
+  const q = new URLSearchParams(window.location.search);
+  if (tenantName && q.get("code")) {
     window.localStorage.setItem(tenantKey, tenantName);
   }
 }

--- a/web/src/services/config/authInfo.ts
+++ b/web/src/services/config/authInfo.ts
@@ -1,0 +1,58 @@
+import { type CognitoParams } from "./aws";
+
+import { config } from ".";
+
+export type AuthInfo = {
+  auth0ClientId?: string;
+  auth0Domain?: string;
+  auth0Audience?: string;
+  authProvider?: string;
+  cognito?: CognitoParams;
+};
+
+export function getAuthInfo(conf = config()): AuthInfo | undefined {
+  return getMultitenantAuthInfo(conf) || defaultAuthInfo(conf);
+}
+
+export function defaultAuthInfo(conf = config()): AuthInfo | undefined {
+  if (!conf) return;
+  return {
+    auth0Audience: conf.auth0Audience,
+    auth0ClientId: conf.auth0ClientId,
+    auth0Domain: conf.auth0Domain,
+    authProvider: conf.authProvider || "auth0",
+    cognito: conf.cognito,
+  };
+}
+
+export function getMultitenantAuthInfo(conf = config()): AuthInfo | undefined {
+  if (!conf?.multitenant) return;
+  const name = getTenantName();
+  if (name) {
+    const tenant = conf.multitenant[name];
+    if (tenant && !tenant.authProvider) {
+      tenant.authProvider = "auth0";
+    }
+    return tenant;
+  }
+  return;
+}
+
+export function getTenantName(): string | undefined {
+  const path = window.location.pathname;
+  if (path.startsWith("/auth/")) {
+    // e.g. /auth/tennant-name?code=xxx&state=xxx
+    const name = path.split("/")[2];
+    return name;
+  }
+  return;
+}
+
+export function getSignInCallbackUrl() {
+  const tenantName = getTenantName();
+  if (tenantName) {
+    // multi-tenant
+    return `${window.location.origin}/auth/${tenantName}`;
+  }
+  return window.location.origin;
+}

--- a/web/src/services/config/aws.ts
+++ b/web/src/services/config/aws.ts
@@ -1,7 +1,5 @@
 import { Amplify } from "aws-amplify";
 
-import { Config } from ".";
-
 export type CognitoParams = {
   region?: string;
   userPoolId?: string;
@@ -13,35 +11,30 @@ export type CognitoParams = {
   oauthResponseType?: string;
 };
 
-export const configureCognito = (config: Config) => {
-  const cognitoConfig = config.cognito;
-  const authProvider = config.authProvider;
+export const configureCognito = (cognitoConfig: CognitoParams) => {
+  const cognitoRegion = cognitoConfig?.region;
+  const cognitoUserPoolId = cognitoConfig?.userPoolId;
+  const cognitoUserPoolWebClientId = cognitoConfig?.userPoolWebClientId;
+  const cognitoOauthScope = cognitoConfig?.oauthScope?.split(", ");
+  const cognitoOauthDomain = cognitoConfig?.oauthDomain;
+  const cognitoOauthRedirectSignIn = cognitoConfig?.oauthRedirectSignIn;
+  const cognitoOauthRedirectSignOut = cognitoConfig?.oauthRedirectSignOut;
+  const cognitoOauthResponseType = cognitoConfig?.oauthResponseType;
 
-  if (cognitoConfig && authProvider === "cognito") {
-    const cognitoRegion = cognitoConfig?.region;
-    const cognitoUserPoolId = cognitoConfig?.userPoolId;
-    const cognitoUserPoolWebClientId = cognitoConfig?.userPoolWebClientId;
-    const cognitoOauthScope = cognitoConfig?.oauthScope?.split(", ");
-    const cognitoOauthDomain = cognitoConfig?.oauthDomain;
-    const cognitoOauthRedirectSignIn = cognitoConfig?.oauthRedirectSignIn;
-    const cognitoOauthRedirectSignOut = cognitoConfig?.oauthRedirectSignOut;
-    const cognitoOauthResponseType = cognitoConfig?.oauthResponseType;
-
-    const config = {
-      Auth: {
-        region: cognitoRegion,
-        userPoolId: cognitoUserPoolId,
-        userPoolWebClientId: cognitoUserPoolWebClientId,
-        oauth: {
-          scope: cognitoOauthScope,
-          domain: cognitoOauthDomain,
-          redirectSignIn: cognitoOauthRedirectSignIn,
-          redirectSignOut: cognitoOauthRedirectSignOut,
-          responseType: cognitoOauthResponseType,
-        },
+  const config = {
+    Auth: {
+      region: cognitoRegion,
+      userPoolId: cognitoUserPoolId,
+      userPoolWebClientId: cognitoUserPoolWebClientId,
+      oauth: {
+        scope: cognitoOauthScope,
+        domain: cognitoOauthDomain,
+        redirectSignIn: cognitoOauthRedirectSignIn,
+        redirectSignOut: cognitoOauthRedirectSignOut,
+        responseType: cognitoOauthResponseType,
       },
-    };
+    },
+  };
 
-    Amplify.configure(config);
-  }
+  Amplify.configure(config);
 };

--- a/web/src/services/config/index.ts
+++ b/web/src/services/config/index.ts
@@ -7,7 +7,7 @@ import { type Extensions, loadExtensions } from "./extensions";
 import { type PasswordPolicy, convertPasswordPolicy } from "./passwordPolicy";
 import { type UnsafeBuiltinPlugin, loadUnsafeBuiltinPlugins } from "./unsafeBuiltinPlugin";
 
-export { getAuthInfo, getSignInCallbackUrl } from "./authInfo";
+export { getAuthInfo, getSignInCallbackUrl, logInToTenant, logOutFromTenant } from "./authInfo";
 
 export type Config = {
   version?: string;
@@ -46,7 +46,7 @@ export type Config = {
   unsafePluginUrls?: string[];
   extensions?: Extensions;
   unsafeBuiltinPlugins?: UnsafeBuiltinPlugin[];
-  multitenant?: Record<string, AuthInfo>;
+  multiTenant?: Record<string, AuthInfo>;
 } & AuthInfo;
 
 declare global {

--- a/web/src/services/config/index.ts
+++ b/web/src/services/config/index.ts
@@ -1,11 +1,13 @@
 import { type Viewer } from "cesium";
 
-import { AuthInfo, getAuthInfo } from "./authInfo";
+import { type AuthInfo, getAuthInfo } from "./authInfo";
 import { configureCognito } from "./aws";
 import { defaultConfig } from "./defaultConfig";
 import { type Extensions, loadExtensions } from "./extensions";
 import { type PasswordPolicy, convertPasswordPolicy } from "./passwordPolicy";
 import { type UnsafeBuiltinPlugin, loadUnsafeBuiltinPlugins } from "./unsafeBuiltinPlugin";
+
+export { getAuthInfo, getSignInCallbackUrl } from "./authInfo";
 
 export type Config = {
   version?: string;
@@ -65,7 +67,7 @@ export default async function loadConfig() {
   };
 
   const authInfo = getAuthInfo(config);
-  if (authInfo?.cognito) {
+  if (authInfo?.cognito && authInfo.authProvider === "cognito") {
     configureCognito(authInfo.cognito);
   }
 

--- a/web/src/services/config/index.ts
+++ b/web/src/services/config/index.ts
@@ -1,6 +1,7 @@
 import { type Viewer } from "cesium";
 
-import { type CognitoParams, configureCognito } from "./aws";
+import { AuthInfo, getAuthInfo } from "./authInfo";
+import { configureCognito } from "./aws";
 import { defaultConfig } from "./defaultConfig";
 import { type Extensions, loadExtensions } from "./extensions";
 import { type PasswordPolicy, convertPasswordPolicy } from "./passwordPolicy";
@@ -11,11 +12,6 @@ export type Config = {
   api: string;
   plugins: string;
   published: string;
-  auth0ClientId?: string;
-  auth0Domain?: string;
-  auth0Audience?: string;
-  authProvider?: string;
-  cognito?: CognitoParams;
   googleApiKey?: string;
   googleClientId?: string;
   sentryDsn?: string;
@@ -48,7 +44,8 @@ export type Config = {
   unsafePluginUrls?: string[];
   extensions?: Extensions;
   unsafeBuiltinPlugins?: UnsafeBuiltinPlugin[];
-};
+  multitenant?: Record<string, AuthInfo>;
+} & AuthInfo;
 
 declare global {
   let __APP_VERSION__: string;
@@ -67,8 +64,9 @@ export default async function loadConfig() {
     ...(await (await fetch("/reearth_config.json")).json()),
   };
 
-  if (config?.cognito) {
-    configureCognito(config);
+  const authInfo = getAuthInfo(config);
+  if (authInfo?.cognito) {
+    configureCognito(authInfo.cognito);
   }
 
   if (config?.passwordPolicy) {

--- a/web/src/services/gql/__gen__/graphql.ts
+++ b/web/src/services/gql/__gen__/graphql.ts
@@ -745,7 +745,7 @@ export type Me = {
   email: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   lang: Scalars['Lang']['output'];
-  myTeam: Team;
+  myTeam?: Maybe<Team>;
   myTeamId: Scalars['ID']['output'];
   name: Scalars['String']['output'];
   teams: Array<Team>;
@@ -1660,6 +1660,7 @@ export type Project = Node & {
   coreSupport: Scalars['Boolean']['output'];
   createdAt: Scalars['DateTime']['output'];
   description: Scalars['String']['output'];
+  enableGa: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
   imageUrl?: Maybe<Scalars['URL']['output']>;
   isArchived: Scalars['Boolean']['output'];
@@ -1674,6 +1675,7 @@ export type Project = Node & {
   scene?: Maybe<Scene>;
   team?: Maybe<Team>;
   teamId: Scalars['ID']['output'];
+  trackingId: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];
   visualizer: Visualizer;
 };
@@ -2540,6 +2542,7 @@ export type UpdateProjectInput = {
   deleteImageUrl?: InputMaybe<Scalars['Boolean']['input']>;
   deletePublicImage?: InputMaybe<Scalars['Boolean']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
+  enableGA?: InputMaybe<Scalars['Boolean']['input']>;
   imageUrl?: InputMaybe<Scalars['URL']['input']>;
   isBasicAuthActive?: InputMaybe<Scalars['Boolean']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
@@ -2548,6 +2551,7 @@ export type UpdateProjectInput = {
   publicImage?: InputMaybe<Scalars['String']['input']>;
   publicNoIndex?: InputMaybe<Scalars['Boolean']['input']>;
   publicTitle?: InputMaybe<Scalars['String']['input']>;
+  trackingId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdatePropertyItemInput = {
@@ -2700,6 +2704,7 @@ export type UploadPluginPayload = {
 export type User = Node & {
   __typename?: 'User';
   email: Scalars['String']['output'];
+  host?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
 };
@@ -3343,7 +3348,7 @@ export type GetUserBySearchQuery = { __typename?: 'Query', searchUser?: { __type
 export type GetMeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetMeQuery = { __typename?: 'Query', me?: { __typename?: 'Me', id: string, name: string, email: string, lang: string, theme: Theme, auths: Array<string>, myTeam: { __typename?: 'Team', id: string, name: string, policyId?: string | null, policy?: { __typename?: 'Policy', id: string, name: string, projectCount?: number | null, memberCount?: number | null, publishedProjectCount?: number | null, layerCount?: number | null, assetStorageSize?: number | null, datasetSchemaCount?: number | null, datasetCount?: number | null } | null }, teams: Array<{ __typename?: 'Team', id: string, name: string, policyId?: string | null, members: Array<{ __typename?: 'TeamMember', userId: string, role: Role, user?: { __typename?: 'User', id: string, name: string, email: string } | null }>, policy?: { __typename?: 'Policy', id: string, name: string, projectCount?: number | null, memberCount?: number | null, publishedProjectCount?: number | null, layerCount?: number | null, assetStorageSize?: number | null, datasetSchemaCount?: number | null, datasetCount?: number | null } | null }> } | null };
+export type GetMeQuery = { __typename?: 'Query', me?: { __typename?: 'Me', id: string, name: string, email: string, lang: string, theme: Theme, auths: Array<string>, myTeam?: { __typename?: 'Team', id: string, name: string, policyId?: string | null, policy?: { __typename?: 'Policy', id: string, name: string, projectCount?: number | null, memberCount?: number | null, publishedProjectCount?: number | null, layerCount?: number | null, assetStorageSize?: number | null, datasetSchemaCount?: number | null, datasetCount?: number | null } | null } | null, teams: Array<{ __typename?: 'Team', id: string, name: string, policyId?: string | null, members: Array<{ __typename?: 'TeamMember', userId: string, role: Role, user?: { __typename?: 'User', id: string, name: string, email: string } | null }>, policy?: { __typename?: 'Policy', id: string, name: string, projectCount?: number | null, memberCount?: number | null, publishedProjectCount?: number | null, layerCount?: number | null, assetStorageSize?: number | null, datasetSchemaCount?: number | null, datasetCount?: number | null } | null }> } | null };
 
 export type UpdateMeMutationVariables = Exact<{
   name?: InputMaybe<Scalars['String']['input']>;
@@ -3355,7 +3360,7 @@ export type UpdateMeMutationVariables = Exact<{
 }>;
 
 
-export type UpdateMeMutation = { __typename?: 'Mutation', updateMe?: { __typename?: 'UpdateMePayload', me: { __typename?: 'Me', id: string, name: string, email: string, lang: string, theme: Theme, myTeam: { __typename?: 'Team', id: string, name: string } } } | null };
+export type UpdateMeMutation = { __typename?: 'Mutation', updateMe?: { __typename?: 'UpdateMePayload', me: { __typename?: 'Me', id: string, name: string, email: string, lang: string, theme: Theme, myTeam?: { __typename?: 'Team', id: string, name: string } | null } } | null };
 
 export type DeleteMeMutationVariables = Exact<{
   userId: Scalars['ID']['input'];

--- a/web/src/services/routing/index.tsx
+++ b/web/src/services/routing/index.tsx
@@ -54,6 +54,7 @@ export const AppRoutes = () => {
         <Route path="login" element={<LoginPage />} />
         <Route path="signup" element={<SignupPage />} />
         <Route path="password-reset" element={<PasswordResetPage />} />
+        <Route path="dashboard" element={<Dashboard />} />
         <Route path="dashboard/:workspaceId" element={<Dashboard />} />
         <Route path="edit/:sceneId">
           <Route index={true} element={<EarthEditor />} />

--- a/web/src/services/routing/index.tsx
+++ b/web/src/services/routing/index.tsx
@@ -50,6 +50,7 @@ export const AppRoutes = () => {
         {/* Beta routes - end */}
         {/* classic routes - start */}
         <Route index={true} element={<RootPage />} />
+        <Route path="auth/*" element={<RootPage />} />
         <Route path="login" element={<LoginPage />} />
         <Route path="signup" element={<SignupPage />} />
         <Route path="password-reset" element={<PasswordResetPage />} />
@@ -81,8 +82,8 @@ export const AppRoutes = () => {
         {...redirects.map(([from, to]) => (
           <Route key={from} path={from} element={<Redirect to={to} />} />
         ))}
-        <Route path="*" element={<NotFound />} />
         {/* classic routes - end */}
+        <Route path="*" element={<NotFound />} />
       </>,
     ),
   );


### PR DESCRIPTION
# Changed

- Add `multitenant` config to reearth_config.json
- Add `/auth/<tenant name>` page to login with an other tenant
- Make `team` field in `me` gql query optional (because if you are a guest, me is present but my workspace is not present)
- If there is no current workspace, project creation button should not bwork
- Refactor some workspace types
- Pretty-print config

# How to test

Both front-end and back-end should be set up:

- Auth0
  - Crate a new app and specify callback url: `<reearth origin>/auth/<tenant name>`
- front-end
   - Add auth info to reearth-config.json: `"multipletenant": { "<tenant name>": { "auth0Domain": "xxx", ... } }`
- back-end
   - Specify `REEARTH_DB_USERS` env vars: e.g. `<tennant name>=<DB URL>`
   - Specify `REEARTH_AUTH_ISS`: e.g. Auth0 domain
   - Specify `REEARTH_AUTH_AUD`: e.g. Auth0 audience

Then access `<reearth origin>/auth/<tenant name>` to login with the tenant.
