### PR TITLE
fix(web): selection without groundPrimitives

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/Feature/HeatMap/HeatmapMesh.tsx
+++ b/web/src/beta/lib/core/engines/Cesium/Feature/HeatMap/HeatmapMesh.tsx
@@ -62,7 +62,7 @@ export const HeatmapMesh = memo(
       ref,
     ) => {
       const { scene } = useCesium();
-      const groundPrimitives = scene?.primitives;
+      const groundPrimitives = scene?.groundPrimitives;
       const primitiveRef = useRef<GroundPrimitive>();
 
       const material = useConstant(() =>

--- a/web/src/beta/lib/core/engines/Cesium/pickMany.ts
+++ b/web/src/beta/lib/core/engines/Cesium/pickMany.ts
@@ -221,6 +221,8 @@ function pickManyFromViewport(
   windowWidth: number,
   windowHeight: number,
 ): object[] {
+  const showGroundPrimitives = scene.groundPrimitives.show;
+  scene.groundPrimitives.show = false;
   invariant(windowWidth > 0 && windowHeight > 0);
   assertType<PrivateScene>(scene);
   const context = scene.context;
@@ -271,6 +273,8 @@ function pickManyFromViewport(
   // Use our pickFramebufferEnd instead of PickFramebuffer.pick().
   const objects = pickFramebufferEnd.apply(view.pickFramebuffer, [rectangleScratch]);
   context.endFrame();
+
+  scene.groundPrimitives.show = showGroundPrimitives;
 
   return objects;
 }


### PR DESCRIPTION
# Overview
This PR fixes an issue faced with pickMany when a groundPrimitive(like heatMap) is present in the scene.