### PR TITLE
chore(web): fix beta editor dnd

### DIFF
--- a/web/src/beta/components/DragAndDropList/Item.tsx
+++ b/web/src/beta/components/DragAndDropList/Item.tsx
@@ -1,7 +1,7 @@
 import type { Identifier } from "dnd-core";
 import type { FC, ReactNode } from "react";
 import { memo, useRef, createContext, useContext } from "react";
-import { ConnectDragSource, useDrag, useDrop } from "react-dnd";
+import { ConnectDragPreview, ConnectDragSource, useDrag, useDrop } from "react-dnd";
 
 import { styled } from "@reearth/services/theme";
 
@@ -22,7 +22,10 @@ type Props = {
   children: ReactNode;
 };
 
-const ItemContext = createContext<ConnectDragSource | null>(null);
+const ItemContext = createContext<{
+  customDragSource: ConnectDragSource;
+  customDragPreview: ConnectDragPreview;
+} | null>(null);
 
 export const useItemContext = () => useContext(ItemContext);
 
@@ -100,10 +103,9 @@ const Item: FC<Props> = ({
   drop(contentRef);
 
   return shouldUseCustomHandler ? (
-    <ItemContext.Provider value={drag}>
+    <ItemContext.Provider value={{ customDragSource: drag, customDragPreview: preview }}>
       <SItem
         customHandler={shouldUseCustomHandler}
-        ref={preview}
         data-handler-id={handlerId}
         isDragging={isDragging}>
         <div ref={contentRef}>{children}</div>

--- a/web/src/beta/components/DragAndDropList/Item.tsx
+++ b/web/src/beta/components/DragAndDropList/Item.tsx
@@ -1,7 +1,7 @@
 import type { Identifier } from "dnd-core";
 import type { FC, ReactNode } from "react";
 import { memo, useRef, createContext, useContext } from "react";
-import { useDrag, useDrop } from "react-dnd";
+import { ConnectDragSource, useDrag, useDrop } from "react-dnd";
 
 import { styled } from "@reearth/services/theme";
 
@@ -22,7 +22,7 @@ type Props = {
   children: ReactNode;
 };
 
-const ItemContext = createContext<React.RefObject<HTMLDivElement> | null>(null);
+const ItemContext = createContext<ConnectDragSource | null>(null);
 
 export const useItemContext = () => useContext(ItemContext);
 
@@ -36,7 +36,6 @@ const Item: FC<Props> = ({
   onItemDropOnItem,
   onItemDropOutside,
 }) => {
-  const ref = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
 
   const [{ handlerId }, drop] = useDrop<DragItem, void, { handlerId: Identifier | null }>({
@@ -98,10 +97,10 @@ const Item: FC<Props> = ({
     },
   });
 
-  drag(ref);
   drop(contentRef);
+
   return shouldUseCustomHandler ? (
-    <ItemContext.Provider value={ref}>
+    <ItemContext.Provider value={drag}>
       <SItem
         customHandler={shouldUseCustomHandler}
         ref={preview}
@@ -111,7 +110,7 @@ const Item: FC<Props> = ({
       </SItem>
     </ItemContext.Provider>
   ) : (
-    <SItem ref={ref} data-handler-id={handlerId} isDragging={isDragging}>
+    <SItem ref={drag} data-handler-id={handlerId} isDragging={isDragging}>
       <div ref={contentRef}>{children}</div>
     </SItem>
   );

--- a/web/src/beta/lib/core/shared/components/SelectableArea/ActionPanel/hooks.ts
+++ b/web/src/beta/lib/core/shared/components/SelectableArea/ActionPanel/hooks.ts
@@ -30,7 +30,7 @@ export default ({
   onSettingsToggle,
 }: Props) => {
   const t = useT();
-  const dndCustomHandleRef = useDnDItemContext();
+  const { customDragSource } = useDnDItemContext() ?? {};
 
   const handleRemove = useCallback(() => {
     onRemove?.();
@@ -86,7 +86,7 @@ export default ({
   }, [title, icon, isSelected, editMode, contentSettings, t, onEditModeToggle, onSettingsToggle]);
 
   return {
-    dndCustomHandleRef,
+    customDragSource,
     settingsTitle,
     popoverContent,
     actionItems,

--- a/web/src/beta/lib/core/shared/components/SelectableArea/ActionPanel/hooks.ts
+++ b/web/src/beta/lib/core/shared/components/SelectableArea/ActionPanel/hooks.ts
@@ -30,7 +30,7 @@ export default ({
   onSettingsToggle,
 }: Props) => {
   const t = useT();
-  const dndItemContextRef = useDnDItemContext();
+  const dndCustomHandleRef = useDnDItemContext();
 
   const handleRemove = useCallback(() => {
     onRemove?.();
@@ -86,7 +86,7 @@ export default ({
   }, [title, icon, isSelected, editMode, contentSettings, t, onEditModeToggle, onSettingsToggle]);
 
   return {
-    dndItemContextRef,
+    dndCustomHandleRef,
     settingsTitle,
     popoverContent,
     actionItems,

--- a/web/src/beta/lib/core/shared/components/SelectableArea/ActionPanel/index.tsx
+++ b/web/src/beta/lib/core/shared/components/SelectableArea/ActionPanel/index.tsx
@@ -59,7 +59,7 @@ const ActionPanel: React.FC<Props> = ({
   onRemove,
   ...actionProps
 }) => {
-  const { dndCustomHandleRef, settingsTitle, popoverContent, actionItems } = useHooks({
+  const { customDragSource, settingsTitle, popoverContent, actionItems } = useHooks({
     title,
     icon,
     isSelected,
@@ -73,7 +73,7 @@ const ActionPanel: React.FC<Props> = ({
 
   return (
     <ActionPanelUI
-      ref={dndCustomHandleRef}
+      ref={customDragSource}
       dndEnabled={dndEnabled}
       isSelected={isSelected}
       actionItems={actionItems}

--- a/web/src/beta/lib/core/shared/components/SelectableArea/ActionPanel/index.tsx
+++ b/web/src/beta/lib/core/shared/components/SelectableArea/ActionPanel/index.tsx
@@ -59,7 +59,7 @@ const ActionPanel: React.FC<Props> = ({
   onRemove,
   ...actionProps
 }) => {
-  const { dndItemContextRef, settingsTitle, popoverContent, actionItems } = useHooks({
+  const { dndCustomHandleRef, settingsTitle, popoverContent, actionItems } = useHooks({
     title,
     icon,
     isSelected,
@@ -73,7 +73,7 @@ const ActionPanel: React.FC<Props> = ({
 
   return (
     <ActionPanelUI
-      ref={dndItemContextRef}
+      ref={dndCustomHandleRef}
       dndEnabled={dndEnabled}
       isSelected={isSelected}
       actionItems={actionItems}

--- a/web/src/beta/lib/core/shared/components/SelectableArea/index.tsx
+++ b/web/src/beta/lib/core/shared/components/SelectableArea/index.tsx
@@ -1,5 +1,6 @@
 import { MouseEvent, ReactNode } from "react";
 
+import { useItemContext as useDnDItemContext } from "@reearth/beta/components/DragAndDropList/Item";
 import { ValueType, ValueTypes } from "@reearth/beta/utils/value";
 import { styled } from "@reearth/services/theme";
 
@@ -83,6 +84,7 @@ const SelectableArea: React.FC<Props> = ({
     onEditModeToggle,
     onClickAway,
   });
+  const { customDragPreview } = useDnDItemContext() ?? {};
 
   return !isEditable ? (
     <>{children}</>
@@ -94,7 +96,7 @@ const SelectableArea: React.FC<Props> = ({
         hideHoverUI={hideHoverUI}
         onMouseOver={handleHoverChange(true)}
         onMouseOut={handleHoverChange(false)}>
-        <div onClick={onClick} onDoubleClick={onDoubleClick}>
+        <div ref={customDragPreview} onClick={onClick} onDoubleClick={onDoubleClick}>
           {children}
         </div>
         {(isSelected || (!hideHoverUI && isHovered)) && (


### PR DESCRIPTION
# Overview

## What I've done
- Fix freeze on story blocks or infobox blocks if dnd drops outside of an item (needed to deselect and reselect again to do more dnd)
- Now non-selected items can dnd
- Moved preview to not include all of SelectArea. This cleans up the preview a bit so you don't see the select border, etc. The implementation adds a customPreview ref, so I think in the future we can customize the preview however we want.