### PR TITLE
ci(server): fix server build failed

### DIFF
--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -43,7 +43,6 @@ jobs:
           args: release --clean ${{ env.SNAPSHOT }}
           workdir: server
         env:
-          SNAPSHOT: ${{ github.event.inputs.new_tag != 'blank' && '--snapshot' || '' }}
           GORELEASER_CURRENT_TAG: ${{ github.event.inputs.new_tag == 'blank' && '0.0.0' || github.event.inputs.new_tag }}
       - name: Rename artifacts
         if: ${{ github.event.inputs.name != 'blank' }}

--- a/.github/workflows/build_server.yml
+++ b/.github/workflows/build_server.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean ${{ env.SNAPSHOT }}
+          args: release --clean ${{ github.event.inputs.new_tag == 'blank' && '--snapshot' || '' }}
           workdir: server
         env:
           GORELEASER_CURRENT_TAG: ${{ github.event.inputs.new_tag == 'blank' && '0.0.0' || github.event.inputs.new_tag }}

--- a/server/.goreleaser.yml
+++ b/server/.goreleaser.yml
@@ -32,3 +32,5 @@ changelog:
   skip: true
 release:
   disable: true
+snapshot:
+  name_template: "{{ .Tag }}-SNAPSHOT-{{ .ShortCommit }}"

--- a/server/.goreleaser.yml
+++ b/server/.goreleaser.yml
@@ -20,11 +20,8 @@ builds:
 archives:
   - name_template: >-
       {{ .ProjectName }}_
-      {{ .Version .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
+      {{- if .IsSnapshot }}{{ .Version }}{{- else }}{{ .Version }}_{{ .Os }}_{{ if eq .Arch "amd64" }}x86_64{{ else if eq .Arch "386" }}i386{{ else }}{{ .Arch }}{{ end }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ end }}
+
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
# Overview
This PR fixes a recurring bug with server build which had to with the newer version of goreleaser which utilizes Snapshots slight differently.