### PR TITLE
ci: add cesium token cron

### DIFF
--- a/.github/workflows/_upload_cesium_token_txt.yml
+++ b/.github/workflows/_upload_cesium_token_txt.yml
@@ -1,0 +1,35 @@
+name: Upload Cesium Ion token
+on:
+  workflow_call:
+    inputs:
+      gcs_dst:
+        type: string
+        required: true
+    secrets:
+      credentials_json:
+        required: true
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.credentials_json }}
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Upload Ion token
+        id: ion_token
+        run: |
+          cesium_ion_token_txt_path="/tmp/cesium_ion_token.txt"
+          curl https://raw.githubusercontent.com/CesiumGS/cesium/main/packages/engine/Source/Core/Ion.js > /tmp/Ion.js
+          cat /tmp/Ion.js | node -e "console.log(require('fs').readFileSync(process.stdin.fd).toString().match(/const defaultAccessToken =(\n| ).*\"(.*)\";/)[2])" | tr -d '\n' >> ${cesium_ion_token_txt_path}
+          token_length=$(cat ${cesium_ion_token_txt_path} | wc -c)
+          if [ $token_length -ne 177 ]; then
+            echo "Token length is invalid. TokenLength: ${token_length}"
+            exit 1
+          fi
+          gsutil cp ${cesium_ion_token_txt_path} ${{ inputs.gcs_dst }}/cesium_ion_token.txt

--- a/.github/workflows/cron_ion_token.yml
+++ b/.github/workflows/cron_ion_token.yml
@@ -1,0 +1,12 @@
+name: Update Cesium Ion token
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 2 * *'
+jobs:
+  upload:
+    uses: ./.github/workflows/_upload_cesium_token_txt.yml
+    with:
+      gcs_dst: gs://test.reearth.dev
+    secrets:
+      credentials_json: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/update_esium_ion_token_nightly.yml
+++ b/.github/workflows/update_esium_ion_token_nightly.yml
@@ -1,8 +1,10 @@
-name: Update Cesium Ion token
+name: Update Cesium Ion token Nightly
+
+# Every 2nd day of the month at 02:00 JST.
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 2 * *'
+    - cron: '0 17 1 * *'
 jobs:
   upload:
     uses: ./.github/workflows/_upload_cesium_token_txt.yml


### PR DESCRIPTION
# Overview
Added cesium token cron for monthly updates

## What I've done
* Upload cesium ion token to gcs by cron

## What I haven't done

## How I tested
I have not been able to check the test because the inability to reference secrets in the forked branch.

## Which point I want you to review particularly

## Memo
This issue is related to the following PR. 
Additionally, the functionality has been tested in the Internal PR associated with the following PR.
ref https://github.com/reearth/reearth/pull/949