### PR TITLE
fix(web): timeline visibility update on viewer change

### DIFF
--- a/web/src/beta/lib/core/engines/Cesium/hooks.ts
+++ b/web/src/beta/lib/core/engines/Cesium/hooks.ts
@@ -930,7 +930,7 @@ export default ({
         : "hidden";
     }
     viewer.forceResize();
-  }, [property]);
+  }, [property, cesium.current?.cesiumElement]);
 
   const globe = cesium.current?.cesiumElement?.scene.globe;
 


### PR DESCRIPTION
# Overview
Fixes timeline visibility on viewer reinitialization.

- Before:
![image](https://github.com/reearth/reearth/assets/59594558/e7ff0ee0-8446-4337-9d86-1140911b6f36)

- After:
![CleanShot 2024-04-21 at 19 03 54](https://github.com/reearth/reearth/assets/59594558/ce937960-3596-40ef-addd-748c5722734b)


## What I've done
- Added `cesium.current?.cesiumElement` to `useEffect` dependencies to trigger updates on viewer changes.

## Remove the index if the feature is unloaded.
## What I haven't done
## How I tested
## Which point I want you to review particularly
## Memo