### PR TITLE
chore(web): remove jotai provider for beta editor

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -1,3 +1,4 @@
+import { Provider as StateProvider } from "jotai";
 import { Suspense } from "react";
 
 import Loading from "@reearth/beta/components/Loading";
@@ -16,11 +17,13 @@ export default function App() {
       <GqlProvider>
         <ThemeProvider>
           <I18nProvider>
-            <Suspense fallback={<Loading animationSize={80} animationColor="#3B3CD0" />}>
-              <NotificationBanner />
-              <GlobalModal />
-              <AppRoutes />
-            </Suspense>
+            <StateProvider>
+              <Suspense fallback={<Loading animationSize={80} animationColor="#3B3CD0" />}>
+                <NotificationBanner />
+                <GlobalModal />
+                <AppRoutes />
+              </Suspense>
+            </StateProvider>
           </I18nProvider>
         </ThemeProvider>
       </GqlProvider>

--- a/web/src/beta/pages/EditorPage/index.tsx
+++ b/web/src/beta/pages/EditorPage/index.tsx
@@ -1,4 +1,3 @@
-import { Provider as StateProvider } from "jotai";
 import { useParams } from "react-router-dom";
 
 import NotFound from "@reearth/beta/components/NotFound";
@@ -14,12 +13,10 @@ const EditorPage: React.FC<Props> = () => {
   return !sceneId || !tab || !isTab(tab) ? (
     <NotFound />
   ) : (
-    <StateProvider>
-      <Page
-        sceneId={sceneId}
-        renderItem={props => <Editor tab={tab} sceneId={sceneId} {...props} />}
-      />
-    </StateProvider>
+    <Page
+      sceneId={sceneId}
+      renderItem={props => <Editor tab={tab} sceneId={sceneId} {...props} />}
+    />
   );
 };
 


### PR DESCRIPTION
# Overview
Notification component is out of the jotai Provider which makes it can't be used in beta Editor.

## What I've done
Move the Provider to have the Notification included.
But somehow i feel the provider is unnecessary in this case.

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
