### PR TITLE
chore(web): enable sandboxed iframe by default

### DIFF
--- a/web/src/beta/features/Editor/Visualizer/hooks.ts
+++ b/web/src/beta/features/Editor/Visualizer/hooks.ts
@@ -279,7 +279,6 @@ export default ({
     selectedWidgetArea,
     widgetAlignEditorActivated,
     engineMeta,
-    useExperimentalSandbox: false, // TODO: test and use new sandbox in beta solely, removing old way too.
     isVisualizerReady, // Not being used (as of 2024/04)
     zoomedLayerId,
     installableInfoboxBlocks,

--- a/web/src/beta/features/Editor/Visualizer/index.tsx
+++ b/web/src/beta/features/Editor/Visualizer/index.tsx
@@ -56,7 +56,6 @@ const EditorVisualizer: React.FC<Props> = ({
     selectedWidgetArea,
     widgetAlignEditorActivated,
     engineMeta,
-    useExperimentalSandbox,
     zoomedLayerId,
     installableInfoboxBlocks,
     handleLayerSelect,
@@ -92,7 +91,6 @@ const EditorVisualizer: React.FC<Props> = ({
       pluginProperty={pluginProperty}
       // editor
       zoomedLayerId={zoomedLayerId}
-      useExperimentalSandbox={useExperimentalSandbox}
       visualizerRef={visualizerRef}
       currentCamera={currentCamera}
       interactionMode={interactionMode}

--- a/web/src/beta/features/Visualizer/index.tsx
+++ b/web/src/beta/features/Visualizer/index.tsx
@@ -140,7 +140,7 @@ const Visualizer: FC<VisualizerProps> = ({
   pluginProperty,
   story,
   zoomedLayerId,
-  useExperimentalSandbox,
+  useExperimentalSandbox = true,
   visualizerRef,
   currentCamera,
   interactionMode,


### PR DESCRIPTION
# Overview

This PR sets useExperimentalSandbox as true by default for beta.

## What I've done

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
