### PR TITLE
chore(WIP): Support plugin block in Beta infobox

### DIFF
--- a/web/src/services/api/infoboxApi/blocks.ts
+++ b/web/src/services/api/infoboxApi/blocks.ts
@@ -151,7 +151,7 @@ const getInstallableInfoboxBlocks = (rawScene?: GetSceneQuery) => {
       return plugin?.extensions
         .filter(
           e =>
-            e.type === PluginExtensionType.InfoboxBlock &&
+            [PluginExtensionType.Block, PluginExtensionType.InfoboxBlock].includes(e.type) &&
             (AVAILABLE_INFOBOX_BLOCK_IDS.includes(`reearth/${e.extensionId}`) ||
               plugin.id !== "reearth"),
         )


### PR DESCRIPTION
# Overview

## What I've done
adding plugins query
<img width="413" alt="スクリーンショット 2024-05-25 2 14 30" src="https://github.com/reearth/reearth/assets/66056064/73e5faa2-24ce-4277-baf2-05db9b4f410d">

## What I haven't done
graphql mutation error
<img width="1106" alt="スクリーンショット 2024-05-25 2 15 37" src="https://github.com/reearth/reearth/assets/66056064/d2d60c5a-c30a-4452-9946-b12945b17996">


## How I tested

## Which point I want you to review particularly

## Memo

According to the error message, the addNLSInfoboxBlock mutation is designed to accept only extensions of type PluginExtensionType.Block. Therefore, attempting to add an InfoboxBlock type will result in an error. fixing Backend is needed to resolve this issue.